### PR TITLE
Add MiniMax model provider support

### DIFF
--- a/apps/console/src/components/pages/settings/RuntimeSettingsEditorState.ts
+++ b/apps/console/src/components/pages/settings/RuntimeSettingsEditorState.ts
@@ -86,12 +86,14 @@ export function applyRuntimeSettingsDefaults(
 
 function defaultModelBaseUrl(vendor: RuntimeSettingsConfig['model']['vendor']): string {
   if (vendor === 'anthropic') return 'https://api.anthropic.com';
+  if (vendor === 'minimax') return 'https://api.minimax.io/v1';
   if (vendor === 'openai_compatible') return 'http://localhost:11434/v1';
   return 'https://api.openai.com/v1';
 }
 
 function defaultModelApiKey(vendor: RuntimeSettingsConfig['model']['vendor']): string {
   if (vendor === 'anthropic') return '${ANTHROPIC_API_KEY}';
+  if (vendor === 'minimax') return '${MINIMAX_API_KEY}';
   if (vendor === 'openai') return '${OPENAI_API_KEY}';
   return '${MODEL_API_KEY}';
 }

--- a/apps/console/src/components/pages/settings/SettingsGeneral.tsx
+++ b/apps/console/src/components/pages/settings/SettingsGeneral.tsx
@@ -13,14 +13,15 @@ export function SettingsGeneral({ data, setView }: { data: ConsoleData; setView:
   const settings = data.settings;
   const savedModel = settings?.saved_config.model;
   const [vendor, setVendor] = useState<RuntimeSettingsConfig['model']['vendor']>(savedModel?.vendor ?? 'openai');
-  const [baseUrl, setBaseUrl] = useState(savedModel?.base_url ?? '');
+  const [baseUrl, setBaseUrl] = useState(savedModel?.base_url ?? defaultModelBaseUrl(savedModel?.vendor));
   const [apiKey, setApiKey] = useState('');
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const baseUrlVendor = vendor === 'openai_compatible' || vendor === 'minimax';
 
   useEffect(() => {
     setVendor(savedModel?.vendor ?? 'openai');
-    setBaseUrl(savedModel?.base_url ?? '');
+    setBaseUrl(savedModel?.base_url ?? defaultModelBaseUrl(savedModel?.vendor));
     setApiKey('');
   }, [savedModel?.vendor, savedModel?.base_url, settings?.revision]);
 
@@ -38,7 +39,7 @@ export function SettingsGeneral({ data, setView }: { data: ConsoleData; setView:
         model: {
           ...settings.saved_config.model,
           vendor,
-          base_url: vendor === 'openai_compatible' ? baseUrl.trim() : undefined,
+          base_url: baseUrlVendor ? baseUrl.trim() || defaultModelBaseUrl(vendor) || undefined : undefined,
           api_key: trimmedKey || (apiKeyConfigured ? settings.saved_config.model.api_key : undefined),
         },
       };
@@ -80,15 +81,20 @@ export function SettingsGeneral({ data, setView }: { data: ConsoleData; setView:
               event.preventDefault();
               void saveModelProvider();
             }}>
-              <FormField label="Provider" description="Keep this simple: OpenAI, Anthropic, or an OpenAI-compatible endpoint.">
-                <select value={vendor} onChange={(event) => setVendor(event.target.value as RuntimeSettingsConfig['model']['vendor'])}>
+              <FormField label="Provider" description="Keep this simple: OpenAI, Anthropic, MiniMax, or an OpenAI-compatible endpoint.">
+                <select value={vendor} onChange={(event) => {
+                  const nextVendor = event.target.value as RuntimeSettingsConfig['model']['vendor'];
+                  setVendor(nextVendor);
+                  setBaseUrl(defaultModelBaseUrl(nextVendor));
+                }}>
                   <option value="openai">OpenAI</option>
                   <option value="anthropic">Anthropic</option>
+                  <option value="minimax">MiniMax</option>
                   <option value="openai_compatible">OpenAI-compatible</option>
                 </select>
               </FormField>
-              {vendor === 'openai_compatible' ? (
-                <FormField label="Base URL" description="Only needed for a compatible gateway or self-hosted model endpoint.">
+              {baseUrlVendor ? (
+                <FormField label="Base URL" description="Use the default endpoint or point to a compatible gateway.">
                   <input value={baseUrl} onChange={(event) => setBaseUrl(event.target.value)} placeholder="https://api.example.com/v1" />
                 </FormField>
               ) : null}
@@ -163,6 +169,11 @@ function runtimeDatabasePath(workspace: Workspace | null) {
   return workspace?.databasePath
     ?? workspace?.directories?.database
     ?? (workspace?.dataDir ? `${workspace.dataDir.replace(/\/$/, '')}/data.db` : undefined);
+}
+
+function defaultModelBaseUrl(vendor: RuntimeSettingsConfig['model']['vendor'] | undefined): string {
+  if (vendor === 'minimax') return 'https://api.minimax.io/v1';
+  return '';
 }
 
 function metadataStorageLabel(settings: RuntimeSettings | null, workspace: Workspace | null) {

--- a/apps/console/src/types.ts
+++ b/apps/console/src/types.ts
@@ -319,7 +319,7 @@ export type SettingsAdapterDescriptor = {
 
 export type RuntimeSettingsConfig = {
   schema_version: 1;
-  model: { vendor: 'openai' | 'anthropic' | 'openai_compatible'; base_url?: string; api_key?: string; options: Record<string, unknown> };
+  model: { vendor: 'openai' | 'anthropic' | 'openai_compatible' | 'minimax'; base_url?: string; api_key?: string; options: Record<string, unknown> };
   loop_engine: { provider: 'builtin' | 'harness' | 'codex' | 'claude'; options: { default_max_steps: number; [key: string]: unknown } };
   storage: {
     metadata: { provider: 'sqlite' | 'postgres' | 'mysql'; options: Record<string, unknown> };

--- a/src/core/model/minimax.ts
+++ b/src/core/model/minimax.ts
@@ -1,0 +1,55 @@
+export const MINIMAX_PROVIDER = 'minimax' as const;
+export const MINIMAX_DEFAULT_MODEL = 'MiniMax-M3';
+
+export const MINIMAX_MODELS = [
+  {
+    model_id: 'MiniMax-M3',
+    context_window: 1_000_000,
+    pricing_usd_per_million_tokens: { input: 0.6, output: 2.4, cache_read: 0.12, cache_write: null },
+    input_modalities: ['text', 'image', 'video'],
+    thinking: ['adaptive', 'disabled'],
+  },
+  {
+    model_id: 'MiniMax-M2.7',
+    context_window: 204_800,
+    pricing_usd_per_million_tokens: { input: 0.3, output: 1.2, cache_read: 0.06, cache_write: 0.375 },
+    input_modalities: ['text'],
+    thinking: ['always_on'],
+  },
+] as const;
+
+export const MINIMAX_ENDPOINTS = {
+  global_en: {
+    openai_base_url: 'https://api.minimax.io/v1',
+    anthropic_base_url: 'https://api.minimax.io/anthropic',
+    docs_root: 'https://platform.minimax.io/docs',
+  },
+  cn_zh: {
+    openai_base_url: 'https://api.minimaxi.com/v1',
+    anthropic_base_url: 'https://api.minimaxi.com/anthropic',
+    docs_root: 'https://platform.minimaxi.com/docs',
+  },
+} as const;
+
+export type MiniMaxRegion = keyof typeof MINIMAX_ENDPOINTS;
+
+const MINIMAX_MODEL_IDS = new Set<string>(MINIMAX_MODELS.map((model) => model.model_id));
+
+export function miniMaxModelId(value: unknown): string {
+  return typeof value === 'string' && MINIMAX_MODEL_IDS.has(value)
+    ? value
+    : MINIMAX_DEFAULT_MODEL;
+}
+
+export function miniMaxOpenAiBaseUrl(options: Record<string, unknown> = {}, explicitBaseUrl?: string): string {
+  if (explicitBaseUrl) return explicitBaseUrl;
+  const region = miniMaxRegion(options.region);
+  const configured = region === 'cn_zh' ? options.cn_openai_base_url : options.openai_base_url;
+  return typeof configured === 'string' && configured.trim()
+    ? configured.trim()
+    : MINIMAX_ENDPOINTS[region].openai_base_url;
+}
+
+export function miniMaxRegion(value: unknown): MiniMaxRegion {
+  return value === 'cn_zh' ? 'cn_zh' : 'global_en';
+}

--- a/src/core/settings/adapters.ts
+++ b/src/core/settings/adapters.ts
@@ -1,4 +1,5 @@
 import { sandboxSettingForProvider } from '@/sandbox/provider-names.js';
+import { MINIMAX_DEFAULT_MODEL, MINIMAX_ENDPOINTS, MINIMAX_MODELS, MINIMAX_PROVIDER } from '@/core/model/minimax.js';
 import type { SettingsAvailability } from './schema.js';
 
 export type AdapterStatus = 'available' | 'unavailable' | 'invalid';
@@ -36,6 +37,16 @@ export function describeSettingsAdapters(installedSandboxes: string[] = ['local'
     model: [
       descriptor('openai', 'OpenAI', true, 'runtime', objectSchema()),
       descriptor('anthropic', 'Anthropic', true, 'runtime', objectSchema()),
+      descriptor(MINIMAX_PROVIDER, 'MiniMax', true, 'runtime', objectSchema({
+        model: { type: 'string', enum: MINIMAX_MODELS.map((model) => model.model_id), default: MINIMAX_DEFAULT_MODEL },
+        region: { type: 'string', enum: ['global_en', 'cn_zh'], default: 'global_en' },
+        openai_base_url: { type: 'string', format: 'uri', default: MINIMAX_ENDPOINTS.global_en.openai_base_url },
+        anthropic_base_url: { type: 'string', format: 'uri', default: MINIMAX_ENDPOINTS.global_en.anthropic_base_url },
+        cn_openai_base_url: { type: 'string', format: 'uri', default: MINIMAX_ENDPOINTS.cn_zh.openai_base_url },
+        cn_anthropic_base_url: { type: 'string', format: 'uri', default: MINIMAX_ENDPOINTS.cn_zh.anthropic_base_url },
+        docs_root: { type: 'string', format: 'uri', default: MINIMAX_ENDPOINTS.global_en.docs_root },
+        cn_docs_root: { type: 'string', format: 'uri', default: MINIMAX_ENDPOINTS.cn_zh.docs_root },
+      })),
       descriptor('openai_compatible', 'OpenAI compatible', true, 'runtime', objectSchema()),
     ],
     loop_engine: [

--- a/src/core/settings/schema.ts
+++ b/src/core/settings/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { MINIMAX_PROVIDER } from '@/core/model/minimax.js';
 
 const optionsSchema = z.record(z.unknown()).default({});
 const STORED_SECRET_PREFIX = '__managed_secret__:';
@@ -6,7 +7,7 @@ const STORED_SECRET_PREFIX = '__managed_secret__:';
 export const runtimeSettingsSchema = z.object({
   schema_version: z.literal(1),
   model: z.object({
-    vendor: z.enum(['openai', 'anthropic', 'openai_compatible']),
+    vendor: z.enum(['openai', 'anthropic', 'openai_compatible', MINIMAX_PROVIDER]),
     base_url: z.string().url().optional(),
     api_key: z.string().min(1).optional(),
     options: optionsSchema,
@@ -176,7 +177,7 @@ export function validateRuntimeSettingsCredentials(
 
 export function defaultSettingsAvailability(): SettingsAvailability {
   return {
-    modelVendors: new Set(['openai', 'anthropic', 'openai_compatible']),
+    modelVendors: new Set(['openai', 'anthropic', 'openai_compatible', MINIMAX_PROVIDER]),
     loopEngines: new Set(['builtin']),
     metadataStorage: new Set(['sqlite']),
     artifactStorage: new Set(['local']),

--- a/src/core/settings/store.ts
+++ b/src/core/settings/store.ts
@@ -2,6 +2,7 @@ import type { Database } from '@/core/db/database.js';
 import { relative, resolve, sep } from 'node:path';
 import { resolveEnvVars } from '@/core/config/env-resolver.js';
 import { defaultSettingsAvailability, runtimeSettingsSchema, validateRuntimeSettings, validateRuntimeSettingsCredentials, type RuntimeSettings } from './schema.js';
+import { MINIMAX_PROVIDER, miniMaxModelId, miniMaxOpenAiBaseUrl } from '@/core/model/minimax.js';
 import { sandboxSettingForProvider } from '@/sandbox/provider-names.js';
 import type { ModelConfig } from '@/types/model.js';
 import {
@@ -160,10 +161,12 @@ export function modelConfigFromRuntimeSettings(
   config: RuntimeSettings,
   dataDir?: string,
 ): ModelConfig {
+  const miniMax = config.model.vendor === MINIMAX_PROVIDER;
   return {
     name: 'default',
     provider: config.model.vendor,
-    base_url: config.model.base_url,
+    ...(miniMax ? { model: miniMaxModelId(config.model.options.model) } : {}),
+    base_url: miniMax ? miniMaxOpenAiBaseUrl(config.model.options, config.model.base_url) : config.model.base_url,
     api_key: resolveRuntimeSettingsModelApiKey(db, config.model.api_key, dataDir),
     is_default: true,
   };
@@ -328,6 +331,7 @@ function resolvedOptionalUrl(value?: string): string | undefined {
 
 function normalizeVendor(provider?: string): RuntimeSettings['model']['vendor'] {
   if (provider === 'anthropic') return 'anthropic';
+  if (provider === MINIMAX_PROVIDER) return MINIMAX_PROVIDER;
   if (!provider || provider === 'openai') return 'openai';
   return 'openai_compatible';
 }

--- a/src/core/settings/test.ts
+++ b/src/core/settings/test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { probeKubernetesCluster, resolveKubernetesNamespace } from '@/sandbox/kubernetes-provider.js';
 import type { RuntimeSettings } from './schema.js';
 import { localArtifactStorageDir, runtimeSettingsSecretStates } from './store.js';
+import { MINIMAX_PROVIDER } from '@/core/model/minimax.js';
 
 export type RuntimeSettingsTestArea =
   | 'model'
@@ -111,7 +112,7 @@ function testModel(db: Database, config: RuntimeSettings): RuntimeSettingsTestCh
   const vendor = config.model.vendor;
   checks.push({
     name: 'vendor',
-    status: ['openai', 'anthropic', 'openai_compatible'].includes(vendor) ? 'ok' : 'failed',
+    status: ['openai', 'anthropic', 'openai_compatible', MINIMAX_PROVIDER].includes(vendor) ? 'ok' : 'failed',
     message: `Model vendor is ${vendor}.`,
   });
 

--- a/src/model/registry.ts
+++ b/src/model/registry.ts
@@ -2,7 +2,7 @@
  * Model Provider Registry
  *
  * Manages model configurations and creates Vercel AI SDK LanguageModel instances.
- * Supports: openai (OpenAI-compatible, incl. Ollama/vLLM), anthropic.
+ * Supports: openai (OpenAI-compatible, incl. Ollama/vLLM), anthropic, minimax.
  * Includes retry policy wrapper (Property 14).
  */
 
@@ -10,6 +10,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { wrapLanguageModel, type LanguageModelV1, type LanguageModelV1Middleware } from 'ai';
 import { resolveEnvVars } from '@/core/config/env-resolver.js';
+import { MINIMAX_PROVIDER, miniMaxOpenAiBaseUrl } from '@/core/model/minimax.js';
 import {
   DEFAULT_RETRY_POLICY,
   type ModelConfig,
@@ -259,6 +260,13 @@ function createModelInstance(
         baseURL: baseUrl,
       });
       return openai(model);
+    }
+    case MINIMAX_PROVIDER: {
+      const minimax = createOpenAI({
+        apiKey: apiKey ?? '',
+        baseURL: miniMaxOpenAiBaseUrl({}, baseUrl),
+      });
+      return minimax(model);
     }
     case 'anthropic': {
       const anthropic = createAnthropic({

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -26,7 +26,7 @@ export interface ModelProvider {
 // Model Configuration
 // ============================================================
 
-export type ModelProviderType = 'openai' | 'anthropic' | 'ollama' | string;
+export type ModelProviderType = 'openai' | 'anthropic' | 'ollama' | 'minimax' | string;
 
 export interface ModelConfig {
   /** Reference name in the model registry */

--- a/tests/unit/runtime-settings-forms.test.tsx
+++ b/tests/unit/runtime-settings-forms.test.tsx
@@ -283,6 +283,27 @@ describe('Runtime Settings forms', () => {
     expect(hydrated.sandbox.options.timeout_seconds).toBe(300);
   });
 
+  it('hydrates MiniMax display defaults from the selected model vendor', () => {
+    const adapters: RuntimeSettings['adapters'] = {
+      model: [{ id: 'minimax', label: 'MiniMax', version: '1', status: 'available', restart_policy: 'runtime', options_schema: {} }],
+      loop_engine: [{ id: 'builtin', label: 'Default', version: '1', status: 'available', restart_policy: 'runtime', options_schema: { type: 'object', properties: { default_max_steps: { type: 'integer', default: 25 } } } }],
+      storage: { metadata: [], artifacts: [] },
+      memory: [],
+      sandbox: [{ id: 'local', label: 'Local', version: '1', status: 'available', restart_policy: 'runtime', options_schema: { type: 'object', properties: { timeout_seconds: { type: 'integer', default: 300 } } } }],
+    };
+    const hydrated = applyRuntimeSettingsDefaults({
+      ...config,
+      model: { vendor: 'minimax' as const, options: {} },
+    }, adapters);
+
+    expect(hydrated.model).toMatchObject({
+      vendor: 'minimax',
+      base_url: 'https://api.minimax.io/v1',
+      api_key: '${MINIMAX_API_KEY}',
+      options: {},
+    });
+  });
+
   it('renders memory and loop engine as single-backend forms instead of provider tables', () => {
     const loop = renderToStaticMarkup(<LoopEngineSettingsForm adapters={[{ id: 'builtin', label: 'Default', status: 'available' }]} config={config} onChange={() => {}} />);
     const memory = renderToStaticMarkup(<MemorySettingsForm adapters={[{ id: 'sqlite', label: 'SQLite', status: 'available' }]} config={config} onChange={() => {}} />);

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -9,6 +9,7 @@ import { Database } from '@/core/db/database.js';
 import { activateRuntimeSettings, getOrSeedRuntimeSettings, localArtifactStorageDir, maskRuntimeSettings, modelConfigFromRuntimeSettings, runtimeSettingsSecretStates, saveRuntimeSettings } from '@/core/settings/store.js';
 import { composeRuntimeFromSettings } from '@/core/runtime/composition.js';
 import { ModelRegistry } from '@/model/registry.js';
+import { MINIMAX_ENDPOINTS } from '@/core/model/minimax.js';
 
 // Typed rather than inferred: without the annotation the literal widens
 // (`schema_version: number`, `provider: string`) and every spread of it into a
@@ -80,6 +81,24 @@ describe('Settings V2 schema', () => {
       sandbox: { provider: 'docker', options: { timeout_seconds: 300 } },
     }, availabilityFromDescriptors(descriptors));
     expect(result.valid).toBe(true);
+  });
+
+  it('accepts MiniMax as an available model vendor with regional endpoint defaults', () => {
+    const descriptors = describeSettingsAdapters(['local']);
+    const model = descriptors.model.find((adapter) => adapter.id === 'minimax');
+
+    expect(model).toMatchObject({ label: 'MiniMax', status: 'available' });
+    expect(model?.options_schema.properties).toMatchObject({
+      model: { default: 'MiniMax-M3' },
+      openai_base_url: { default: MINIMAX_ENDPOINTS.global_en.openai_base_url },
+      anthropic_base_url: { default: MINIMAX_ENDPOINTS.global_en.anthropic_base_url },
+      cn_openai_base_url: { default: MINIMAX_ENDPOINTS.cn_zh.openai_base_url },
+      cn_anthropic_base_url: { default: MINIMAX_ENDPOINTS.cn_zh.anthropic_base_url },
+    });
+    expect(validateRuntimeSettings({
+      ...validConfig,
+      model: { vendor: 'minimax', api_key: '${MINIMAX_API_KEY}', options: {} },
+    }, availabilityFromDescriptors(descriptors)).valid).toBe(true);
   });
 
   it('skips live health checks for registered Docker sandbox checks', async () => {
@@ -641,6 +660,28 @@ describe('Settings V2 activation', () => {
     const model = modelConfigFromRuntimeSettings(db, config, directory);
     expect(model).toMatchObject({ name: 'default', provider: 'anthropic' });
     expect(model.model).toBeUndefined();
+    db.close();
+  });
+
+  it('builds MiniMax runtime model defaults from Settings V2', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'ma-settings-minimax-model-'));
+    directories.push(directory);
+    const db = new Database(join(directory, 'settings.db'));
+    db.runMigrations();
+    const initial = getOrSeedRuntimeSettings(db);
+    const config: RuntimeSettings = {
+      ...initial.effective_config,
+      model: { vendor: 'minimax', api_key: '${MINIMAX_API_KEY}', options: { region: 'cn_zh', model: 'MiniMax-M2.7' } },
+    };
+
+    const model = modelConfigFromRuntimeSettings(db, config, directory);
+
+    expect(model).toMatchObject({
+      name: 'default',
+      provider: 'minimax',
+      model: 'MiniMax-M2.7',
+      base_url: MINIMAX_ENDPOINTS.cn_zh.openai_base_url,
+    });
     db.close();
   });
 


### PR DESCRIPTION
Reason: Add first-class MiniMax model provider support for workspace vendor selection.

Changes:
- Added MiniMax model metadata with global and CN OpenAI-compatible and Anthropic-compatible endpoint defaults.
- Added MiniMax to runtime settings validation, adapter descriptors, provider testing, and runtime model config generation.
- Added console defaults so the setup flow can select MiniMax without manual generic-provider wiring.

Checks:
- npm test -- tests/unit/settings.test.ts tests/unit/runtime-settings-forms.test.tsx
- ./node_modules/.bin/tsc --noEmit --pretty false
- ./node_modules/.bin/tsc --noEmit -p tsconfig.tests.json --pretty false
