### PR TITLE
fix(package): point metadata at sandbase-harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.2.0",
   "description": "Local-first, self-hosted AI agent runtime with Claude Managed Agents-style APIs, sandboxed sessions, memory, tools, audit, replay, and a local Console.",
   "type": "module",
-  "homepage": "https://github.com/sandbaseai/managed-agents#readme",
+  "homepage": "https://github.com/sandbaseai/sandbase-harness#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sandbaseai/managed-agents.git"
+    "url": "git+https://github.com/sandbaseai/sandbase-harness.git"
   },
   "publishConfig": {
     "access": "public",
@@ -18,7 +18,7 @@
     }
   },
   "bugs": {
-    "url": "https://github.com/sandbaseai/managed-agents/issues"
+    "url": "https://github.com/sandbaseai/sandbase-harness/issues"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary

Correct stale `homepage`, `repository`, and `bugs` URLs so package metadata and community scanners resolve the current public repository.

## Validation

- JSON remains valid
- change is metadata-only
- required before submitting the DSH integration to the community catalog