### PR TITLE
feat(models): support DeepSeek V4 reasoning effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ Agents pick concrete model IDs (`gpt-4o`, `claude-sonnet-4-20250514`,
 `openai/gpt-5.5`). The workspace config only says how to reach the model
 service.
 
+For DeepSeek V4 Pro/Flash configuration, including maximum reasoning effort,
+see [DeepSeek V4](docs/deepseek-v4.md).
+
 ## CLI
 
 ```bash

--- a/docs/deepseek-v4.md
+++ b/docs/deepseek-v4.md
@@ -1,0 +1,51 @@
+# DeepSeek V4
+
+SandBase Harness can use DeepSeek V4 through DeepSeek's OpenAI-compatible API.
+DeepSeek V4 supports a context window of up to 1 million tokens. The runtime
+compacts long sessions automatically; it does not currently expose a separate
+context-window setting.
+
+## Configure the provider
+
+Set your API key in the environment:
+
+```bash
+export DEEPSEEK_API_KEY="<your DeepSeek API key>"
+```
+
+In Dashboard **Settings > Models**, switch to JSON and configure:
+
+```json
+{
+  "vendor": "openai_compatible",
+  "base_url": "https://api.deepseek.com/v1",
+  "api_key": "${DEEPSEEK_API_KEY}",
+  "options": {
+    "reasoning_effort": "max"
+  }
+}
+```
+
+Save and activate the settings. `reasoning_effort` is forwarded as
+`reasoning_effort` in each OpenAI-compatible chat-completions request. Use
+`max` with DeepSeek V4 Pro for the strongest coding and agent performance.
+
+## Create and run an agent
+
+Create an agent whose model is `deepseek-v4-pro` (or
+`deepseek-v4-flash` for lower latency), then start a session from the Console.
+For a YAML seed definition:
+
+```yaml
+name: deepseek-coder
+model: deepseek-v4-pro
+system: You are a careful coding agent. Inspect the repository, make focused changes, and verify them.
+tools:
+  - type: agent_toolset_20260401
+```
+
+Start the runtime with `npx managed-agents start`, open
+`http://127.0.0.1:3000/dashboard`, select the agent, and send the first task.
+
+Do not commit API keys to the workspace. The `${DEEPSEEK_API_KEY}` reference is
+resolved only by the runtime.

--- a/src/core/settings/store.ts
+++ b/src/core/settings/store.ts
@@ -165,6 +165,9 @@ export function modelConfigFromRuntimeSettings(
     provider: config.model.vendor,
     base_url: config.model.base_url,
     api_key: resolveRuntimeSettingsModelApiKey(db, config.model.api_key, dataDir),
+    reasoning_effort: typeof config.model.options.reasoning_effort === 'string'
+      ? config.model.options.reasoning_effort
+      : undefined,
     is_default: true,
   };
 }

--- a/src/model/registry.ts
+++ b/src/model/registry.ts
@@ -110,7 +110,13 @@ export class ModelRegistry {
     const resolvedApiKey = config.api_key ? resolveEnvVars(config.api_key, false) : undefined;
     const resolvedBaseUrl = config.base_url ? resolveEnvVars(config.base_url, false) : undefined;
 
-    const base = createModelInstance(config.provider, config.model, resolvedApiKey, resolvedBaseUrl);
+    const base = createModelInstance(
+      config.provider,
+      config.model,
+      resolvedApiKey,
+      resolvedBaseUrl,
+      config.reasoning_effort,
+    );
     return wrapLanguageModel({
       model: base,
       middleware: createRetryMiddleware(this.retryPolicy),
@@ -250,6 +256,7 @@ function createModelInstance(
   model: string,
   apiKey?: string,
   baseUrl?: string,
+  reasoningEffort?: string,
 ): LanguageModelV1 {
   switch (provider) {
     case 'openai':
@@ -258,7 +265,7 @@ function createModelInstance(
         apiKey: apiKey ?? 'ollama', // Ollama doesn't need a key
         baseURL: baseUrl,
       });
-      return openai(model);
+      return openai(model, reasoningEffort ? { reasoningEffort: reasoningEffort as 'low' | 'medium' | 'high' } : undefined);
     }
     case 'anthropic': {
       const anthropic = createAnthropic({
@@ -273,7 +280,7 @@ function createModelInstance(
         apiKey: apiKey ?? '',
         baseURL: baseUrl,
       });
-      return openaiCompat(model);
+      return openaiCompat(model, reasoningEffort ? { reasoningEffort: reasoningEffort as 'low' | 'medium' | 'high' } : undefined);
     }
   }
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -43,6 +43,8 @@ export interface ModelConfig {
   temperature?: number;
   /** Max tokens override */
   max_tokens?: number;
+  /** Provider reasoning effort (for example `max` with DeepSeek V4 Pro). */
+  reasoning_effort?: string;
   /** Whether this provider is the default for new agents and templates */
   is_default?: boolean;
 }

--- a/tests/unit/model-registry.test.ts
+++ b/tests/unit/model-registry.test.ts
@@ -49,6 +49,23 @@ describe('ModelRegistry runtime introspection', () => {
     });
   });
 
+  it('preserves provider reasoning effort for resolved model ids', () => {
+    const registry = new ModelRegistry();
+    registry.register({
+      name: 'default',
+      provider: 'openai_compatible',
+      api_key: '${DEEPSEEK_API_KEY}',
+      base_url: 'https://api.deepseek.com/v1',
+      reasoning_effort: 'max',
+      is_default: true,
+    });
+
+    expect(registry.resolveModelConfig('deepseek-v4-pro')).toMatchObject({
+      model: 'deepseek-v4-pro',
+      reasoning_effort: 'max',
+    });
+  });
+
   it('uses the default provider settings for unqualified user model ids', () => {
     const registry = new ModelRegistry();
     registry.register({

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -637,9 +637,12 @@ describe('Settings V2 activation', () => {
     const db = new Database(join(directory, 'settings.db'));
     db.runMigrations();
     const initial = getOrSeedRuntimeSettings(db);
-    const config = { ...initial.effective_config, model: { vendor: 'anthropic' as const, options: {} } };
+    const config = {
+      ...initial.effective_config,
+      model: { vendor: 'anthropic' as const, options: { reasoning_effort: 'max' } },
+    };
     const model = modelConfigFromRuntimeSettings(db, config, directory);
-    expect(model).toMatchObject({ name: 'default', provider: 'anthropic' });
+    expect(model).toMatchObject({ name: 'default', provider: 'anthropic', reasoning_effort: 'max' });
     expect(model.model).toBeUndefined();
     db.close();
   });


### PR DESCRIPTION
## Summary

- forward `model.options.reasoning_effort` to OpenAI-compatible model requests
- document DeepSeek V4 Pro/Flash configuration using current model names
- note DeepSeek V4's 1M context window and provide an installation-to-first-run flow

This closes the compatibility gap needed before publishing a verified SandBase Harness guide to `deepseek-ai/awesome-deepseek-agent`.

## Verification

- `npm run typecheck`
- `npx vitest run tests/unit/model-registry.test.ts tests/unit/settings.test.ts` (46 tests passed)

## Notes

The guide recommends `reasoning_effort: max` for DeepSeek V4 Pro. The runtime does not expose a separate context-window setting, so the 1M capability is stated explicitly rather than represented by an ineffective config key.