### PR TITLE
chore: add Glama maintainer metadata

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "denial123789"
+  ]
+}


### PR DESCRIPTION
## Summary

- add the minimal `glama.json` ownership metadata required for an organization-owned MCP server
- identify the GitHub maintainer who can verify the listing

## Why

This enables SandBase Harness to be claimed and continuously scanned by Glama, which is required for acceptance into the awesome-mcp-servers directory.

## Validation

- `jq empty glama.json`
- `git diff --check`

Glama schema: https://glama.ai/mcp/schemas/server.json