### PR TITLE
docs: link DeepSeek Harness Handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ native `mcp__sandbase__*` tools. See
 [`examples/deepseek-harness`](examples/deepseek-harness/README.md) for the full
 tool list and authenticated-runtime configuration.
 
+New to DSH profiles, plugin composition, tool policy, or session semantics? The
+independent [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook)
+provides source-backed quickstarts, architecture maps, and troubleshooting for
+the runtime layers used by this integration.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## What changed

Adds a concise link from the existing DeepSeek Harness integration section to the independent DeepSeek Harness Handbook.

## Why

Users installing the SandBase bundle into a DSH profile may need background on profiles, plugin composition, tool policy, session events, or platform troubleshooting. The handbook provides that source-backed runtime context while this repository remains the authority for the SandBase-specific tool list and authenticated configuration.

## Validation

- `git diff --check`
- verified the handbook repository resolves publicly
