### PR TITLE
chore: prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.3.0 - 2026-08-14
+
+### Highlights
+
+- **DeepSeek Harness integration**: ships an installable Cordis bundle and the
+  `managed-agents-mcp` stdio server so DSH can create and inspect agents,
+  manage persistent sessions, stream turns, retrieve artifacts, and cancel
+  runs through MCP.
+- **Verified integration guide**: adds a reproducible DSH configuration,
+  permission boundaries, troubleshooting guidance, and compatibility evidence
+  against DeepSeek Harness commit `47f9438`.
+- **DeepSeek V4 reasoning controls**: forwards Settings V2 `reasoning_effort`
+  values to OpenAI-compatible model requests and documents a verified
+  DeepSeek V4 setup.
+- **Distribution metadata**: corrects package repository links to
+  `sandbaseai/sandbase-harness` and adds Glama maintainer metadata for MCP
+  directory verification.
+
 ## 0.2.0 - 2026-08-01
 
 ### Breaking changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "managed-agents",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "managed-agents",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "managed-agents",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Local-first, self-hosted AI agent runtime with Claude Managed Agents-style APIs, sandboxed sessions, memory, tools, audit, replay, and a local Console.",
   "type": "module",
   "homepage": "https://github.com/sandbaseai/sandbase-harness#readme",


### PR DESCRIPTION
## Summary

- bump the package and lockfile version to `0.3.0`
- document the DeepSeek Harness MCP bridge, verified DSH integration, DeepSeek V4 reasoning controls, and distribution metadata
- prepare a stable GitHub Release for the five commits added since `v0.2.0`

## Validation

`env npm_config_cache=/private/tmp/sandbase-harness-v030-npm-cache npm run release:check`

Result:
- typecheck passed
- 76 test files passed; 573 tests passed and 14 transport-dependent tests skipped
- runtime and Console production builds passed
- npm package dry-run passed (44 files)
- release smoke passed

## Release plan

After merge, create GitHub Release `v0.3.0` from `main` using the checked-in changelog. npm publication remains separate.