### PR TITLE
docs: link SandBase CLI from the ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,14 @@ npm run release:check  # full local release gate
 `release:check` runs typecheck, tests, both builds, `npm pack --dry-run`, CLI
 init smoke, and `examples/basic` startup smoke.
 
+## SandBase Ecosystem
+
+- [SandBase CLI](https://github.com/sandbaseai/cli) — connect Cursor, Claude Code,
+  Codex, Windsurf, Gemini CLI, OpenCode, and other MCP clients to 2,000+ tools
+  and 200+ AI models with one onboarding command.
+- [SandBase](https://www.sandbase.ai) — hosted agent infrastructure, model access,
+  tools, and managed sandboxes.
+
 ## Documentation
 
 - [Installation](docs/installation.md)


### PR DESCRIPTION
## What changed

Adds a concise SandBase Ecosystem section linking the CLI and hosted platform from the runtime README.

## Why

The runtime already supports MCP toolsets and SandBase integrations, but visitors had no direct path to the companion CLI that configures major coding-agent clients. The cross-link gives the repository's existing developer audience a relevant next step.

## Validation

- `git diff --check` passes
- documentation-only change; no runtime behavior is modified