### PR TITLE
docs: use tagged source installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,13 @@ credentials, audit trails, and a built-in Console — all running on your
 machine or in your own infrastructure.
 
 ```bash
-npx managed-agents init
-npx managed-agents start
+git clone --branch v0.3.0 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+cd sandbase-harness
+npm ci
+npm run build
+mkdir ../my-agents && cd ../my-agents
+node ../sandbase-harness/dist/index.js init
+node ../sandbase-harness/dist/index.js start
 # open http://127.0.0.1:3000/dashboard
 ```
 
@@ -69,22 +74,31 @@ tool list and authenticated-runtime configuration.
 ## Quick Start
 
 ```bash
-mkdir my-agents && cd my-agents
-npx managed-agents init
-npx managed-agents start
+git clone --branch v0.3.0 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+cd sandbase-harness
+npm ci
+npm run build
+mkdir ../my-agents && cd ../my-agents
+node ../sandbase-harness/dist/index.js init
+node ../sandbase-harness/dist/index.js start
 ```
 
 Open `http://127.0.0.1:3000/dashboard`, go to **Settings > Models**, paste your
 API key, and you're running.
 
-From a source checkout:
+The unscoped `managed-agents` name on npm is not this project. Until an
+official scoped package is announced in this repository, install only from the
+tagged GitHub source release shown above. Do not run `npx managed-agents` or
+`npm install managed-agents`.
+
+For development from the latest `main` branch:
 
 ```bash
-git clone git@github.com:sandbaseai/managed-agents.git
-cd managed-agents && npm ci && npm run build
-cd .. && mkdir my-agents && cd my-agents
-node ../managed-agents/dist/index.js init
-node ../managed-agents/dist/index.js start
+git clone https://github.com/sandbaseai/sandbase-harness.git
+cd sandbase-harness && npm ci && npm run build
+cd .. && mkdir my-agents-dev && cd my-agents-dev
+node ../sandbase-harness/dist/index.js init
+node ../sandbase-harness/dist/index.js start
 ```
 
 ## Workspace Layout

--- a/docs/deepseek-v4.md
+++ b/docs/deepseek-v4.md
@@ -44,7 +44,8 @@ tools:
   - type: agent_toolset_20260401
 ```
 
-Start the runtime with `npx managed-agents start`, open
+From a tagged source checkout, build the runtime and start it with
+`node dist/index.js start`, then open
 `http://127.0.0.1:3000/dashboard`, select the agent, and send the first task.
 
 Do not commit API keys to the workspace. The `${DEEPSEEK_API_KEY}` reference is

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -64,17 +64,27 @@ external access.
 
 ## Docker Compose
 
-This example stores runtime state in a named volume and keeps the HTTP service
-bound to localhost on the host machine.
+Build the image from a tagged SandBase Harness source checkout. The unscoped
+`managed-agents` npm package is not this project and must not be installed in a
+deployment image.
+
+```dockerfile
+FROM node:22-bookworm-slim
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+CMD ["node", "dist/index.js", "start", "--host", "0.0.0.0", "--port", "3000", "--data-dir", "/data"]
+```
+
+This Compose example stores runtime state in a named volume and keeps the HTTP
+service bound to localhost on the host machine:
 
 ```yaml
 services:
   managed-agents:
-    image: node:22-bookworm-slim
-    working_dir: /app
-    command: >
-      sh -lc "npm install -g managed-agents &&
-      managed-agents start --host 0.0.0.0 --port 3000 --data-dir /data"
+    build: .
     ports:
       - "127.0.0.1:3000:3000"
     environment:
@@ -95,7 +105,8 @@ container runtime and permissions are explicitly managed.
 
 ## Kubernetes
 
-Use a `Deployment` for the runtime and a persistent volume for `/data`:
+Push the same source-built image to your registry, then use a `Deployment` for
+the runtime and a persistent volume for `/data`:
 
 ```yaml
 apiVersion: apps/v1
@@ -114,12 +125,18 @@ spec:
     spec:
       containers:
         - name: runtime
-          image: node:22-bookworm-slim
+          image: your-registry.example/sandbase-harness:v0.3.0
           workingDir: /app
           command:
-            - sh
-            - -lc
-            - npm install -g managed-agents && managed-agents start --host 0.0.0.0 --port 3000 --data-dir /data
+            - node
+            - dist/index.js
+            - start
+            - --host
+            - 0.0.0.0
+            - --port
+            - "3000"
+            - --data-dir
+            - /data
           envFrom:
             - secretRef:
                 name: managed-agents-secrets

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,15 +11,22 @@ and the local Console.
 - A model vendor API key or an OpenAI-compatible local endpoint
 - Docker, only when using Docker-backed sandboxes
 
-## Install With npx
+## Install From A Tagged Source Release
 
-Use `npx` when you want to try the runtime without installing a global package:
+The unscoped `managed-agents` package currently visible on npm is not this
+project. Until an official scoped package is announced in this repository, use
+the tagged GitHub source release and do not run `npx managed-agents` or
+`npm install managed-agents`.
 
 ```bash
-mkdir my-agents
-cd my-agents
-npx managed-agents init
-npx managed-agents start
+git clone --branch v0.3.0 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+cd sandbase-harness
+npm ci
+npm run build
+mkdir ../my-agents
+cd ../my-agents
+node ../sandbase-harness/dist/index.js init
+node ../sandbase-harness/dist/index.js start
 ```
 
 The Dashboard will be available at:
@@ -34,26 +41,25 @@ The API will be available at:
 http://127.0.0.1:3000/v1
 ```
 
-## Global Install
+## Optional Source Command Links
 
-Use a global install for a workstation or shared development machine:
+From the tagged source checkout, `npm link` exposes the two locally built
+executables on a workstation. This does not download the unrelated unscoped
+npm package:
 
 ```bash
-npm install -g managed-agents
+cd sandbase-harness
+npm link
+cd ../my-agents
 managed-agents init
 managed-agents start
 ```
 
-Upgrade the global install with:
+Remove the source links with:
 
 ```bash
-npm update -g managed-agents
-```
-
-Remove it with:
-
-```bash
-npm uninstall -g managed-agents
+cd sandbase-harness
+npm unlink -g
 ```
 
 ## Build From Source
@@ -61,8 +67,8 @@ npm uninstall -g managed-agents
 Use a source checkout when contributing to the project:
 
 ```bash
-git clone git@github.com:sandbaseai/managed-agents.git
-cd managed-agents
+git clone https://github.com/sandbaseai/sandbase-harness.git
+cd sandbase-harness
 npm ci
 npm run build
 ```
@@ -81,8 +87,8 @@ Then create a runtime workspace outside the source checkout:
 ```bash
 mkdir ../my-agents
 cd ../my-agents
-node ../managed-agents/dist/index.js init
-node ../managed-agents/dist/index.js start
+node ../sandbase-harness/dist/index.js init
+node ../sandbase-harness/dist/index.js start
 ```
 
 During development, run the TypeScript entry point directly:

--- a/docs/spec/claude-managed-agents-gap.md
+++ b/docs/spec/claude-managed-agents-gap.md
@@ -5,7 +5,7 @@ Reviewed: 2026-07-23
 Repository:
 
 - Local path: `/Users/liyb/Documents/Codex/2026-07-16/new-chat-2/managed-agents`
-- Remote: `git@github.com:sandbaseai/managed-agents.git`
+- Remote: `https://github.com/sandbaseai/sandbase-harness.git`
 - Local HEAD reviewed: `b8979f1e9778f8cc1e56a5cc86048340afd16eec`
 - Remote freshness: not verified in this sandbox because outbound SSH to GitHub is blocked.
 - Worktree state: dirty, with substantial existing product changes. This review preserves the worktree and does not re-clone over it.
@@ -420,4 +420,3 @@ Public alpha can be cut when:
 - A user can create an agent, create a session, mount files/skills/vaults/memory, run the session, inspect events/artifacts, and export a handoff bundle.
 - Docs accurately distinguish implemented, partial, and roadmap behavior.
 - Tests cover runtime settings, capability policy, credential policy, sessions, resources, operations primitives, Console guardrails, and SDK/CLI smoke flows.
-

--- a/docs/spec/v1-local-first-architecture.md
+++ b/docs/spec/v1-local-first-architecture.md
@@ -339,12 +339,13 @@ An adapter can return to public UI/docs only when all of these exist:
 The release smoke test should be simple enough for a new open-source user:
 
 ```bash
-git clone git@github.com:sandbaseai/managed-agents.git
-cd managed-agents
+git clone https://github.com/sandbaseai/sandbase-harness.git
+cd sandbase-harness
 npm ci
 npm run build
-npx managed-agents init
-npx managed-agents start
+mkdir ../my-agents && cd ../my-agents
+node ../sandbase-harness/dist/index.js init
+node ../sandbase-harness/dist/index.js start
 ```
 
 Then verify:

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -5,9 +5,10 @@ A minimal managed-agents setup with a single echo assistant.
 ## Setup
 
 ```bash
-# Start from this directory
+# Build from the repository root, then start from this directory.
+npm run build:runtime
 cd examples/basic
-npx managed-agents start --agents-dir agents --config .managed-agents/config.yaml
+node ../../dist/index.js start --agents-dir agents --config .managed-agents/config.yaml
 ```
 
 Configure model credentials in `.managed-agents/config.yaml` before calling a

--- a/examples/deepseek-harness/README.md
+++ b/examples/deepseek-harness/README.md
@@ -8,17 +8,28 @@ stdio and exposes agents, sessions, streamed turns, artifacts, and cancellation.
 
 - Node.js 22+
 - DeepSeek Harness with `@deepseek-ai/dsh-mcp-client` and stdio MCP support
-- `managed-agents` 0.2.0 or a source build from this repository
+- SandBase Harness v0.3.0 or a source build from this repository
 
 Last verified on 2026-08-14 against DeepSeek Harness commit
 [`47f9438`](https://github.com/deepseek-ai/deepseek-harness/commit/47f943859bef60e4160492346772ded9b24f765a): the Cordis layer composed cleanly,
 DSH launched the stdio child, and the MCP handshake completed.
 
-Start the runtime first:
+Build the tagged source release and expose its two local executables first:
 
 ```bash
-npx managed-agents start
+git clone --branch v0.3.0 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+cd sandbase-harness
+npm ci
+npm run build:runtime
+npm link
+mkdir ../my-agents && cd ../my-agents
+managed-agents init
+managed-agents start
 ```
+
+The unscoped `managed-agents` package on npm is not SandBase Harness. Do not
+use `npx managed-agents`; `npm link` above links only the verified source
+checkout.
 
 In another terminal, install this bundle into the Web profile and start DSH:
 


### PR DESCRIPTION
## Summary

- replace `npx managed-agents` and global npm install instructions with the verified v0.3.0 tagged-source flow
- explicitly warn that the current unscoped npm package is unrelated to SandBase Harness
- update deployment, examples, DeepSeek integration, and historical repository links
- keep optional CLI commands available through a source-local `npm link`

## Why

The public unscoped `managed-agents` npm package is not published by this project. Existing commands could therefore install unrelated code and undermine user trust.

## Validation

- `npm run release:check`
- 76 test files passed, 573 tests passed, 14 transport-dependent tests skipped
- typecheck passed
- runtime and Console builds passed
- package dry-run passed (44 files)
- release smoke passed