### PR TITLE
docs: add community discovery badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# managed-agents
+# SandBase Harness
+
+[![GitHub stars](https://img.shields.io/github/stars/sandbaseai/sandbase-harness?style=social)](https://github.com/sandbaseai/sandbase-harness/stargazers)
+[![Release](https://img.shields.io/github/v/release/sandbaseai/sandbase-harness)](https://github.com/sandbaseai/sandbase-harness/releases/latest)
+[![Discussions](https://img.shields.io/github/discussions/sandbaseai/sandbase-harness)](https://github.com/sandbaseai/sandbase-harness/discussions)
+[![License](https://img.shields.io/github/license/sandbaseai/sandbase-harness)](LICENSE)
 
 A local-first runtime for AI agents. Sessions, sandboxed tools, memory,
 credentials, audit trails, and a built-in Console — all running on your


### PR DESCRIPTION
## What changed

- Use the public project name, SandBase Harness, as the README heading.
- Add visible links for GitHub stars, the latest release, Discussions, and the license.

## Why

The repository now has a verified release and an announcement/feedback forum. These badges make those trust and community surfaces discoverable from the first screen without changing runtime behavior.

## Validation

- `git diff --check`