### PR TITLE
chore: prepare v0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "managed-agents",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "managed-agents",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "managed-agents",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Local-first, self-hosted AI agent runtime with Claude Managed Agents-style APIs, sandboxed sessions, memory, tools, audit, replay, and a local Console.",
   "type": "module",
   "homepage": "https://github.com/sandbaseai/sandbase-harness#readme",


### PR DESCRIPTION
## Summary
- bump runtime and lockfile metadata to v0.3.1
- publish the post-v0.3.0 documentation safety fixes, canonical Apache-2.0 license, ecosystem links, and discovery improvements under a stable tag

## Release gate
- source and test typechecks passed
- 76 test files passed, 2 skipped
- 572 tests passed, 15 skipped
- runtime and console builds passed
- package dry-run passed: 44 files, 732.4 kB tarball
- release smoke passed

The smoke test was rerun outside the filesystem sandbox because it needs to bind a temporary loopback listener; result: `release smoke: ok`.