### PR TITLE
docs: sharpen quick start and update v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ credentials, audit trails, and a built-in Console — all running on your
 machine or in your own infrastructure.
 
 ```bash
-git clone --branch v0.3.0 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.1 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -19,6 +19,16 @@ node ../sandbase-harness/dist/index.js init
 node ../sandbase-harness/dist/index.js start
 # open http://127.0.0.1:3000/dashboard
 ```
+
+Choose SandBase Harness when you need more than a model loop:
+
+| Need | What Harness provides |
+| --- | --- |
+| Run generated code safely | Local, Docker, Kubernetes, and self-hosted worker sandboxes |
+| Inspect long-running agents | Persistent sessions, resumable event streams, audit, and replay |
+| Control tool access | MCP toolsets, credential vaults, permission policies, and approvals |
+| Operate any model | OpenAI, Anthropic, and OpenAI-compatible providers, including DeepSeek V4 |
+| Keep infrastructure yours | Local-first SQLite and file storage with no required hosted control plane |
 
 ## Why
 
@@ -84,7 +94,7 @@ the runtime layers used by this integration.
 ## Quick Start
 
 ```bash
-git clone --branch v0.3.0 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.1 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -125,7 +125,7 @@ spec:
     spec:
       containers:
         - name: runtime
-          image: your-registry.example/sandbase-harness:v0.3.0
+          image: your-registry.example/sandbase-harness:v0.3.1
           workingDir: /app
           command:
             - node

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ the tagged GitHub source release and do not run `npx managed-agents` or
 `npm install managed-agents`.
 
 ```bash
-git clone --branch v0.3.0 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.1 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build

--- a/examples/deepseek-harness/README.md
+++ b/examples/deepseek-harness/README.md
@@ -8,7 +8,7 @@ stdio and exposes agents, sessions, streamed turns, artifacts, and cancellation.
 
 - Node.js 22+
 - DeepSeek Harness with `@deepseek-ai/dsh-mcp-client` and stdio MCP support
-- SandBase Harness v0.3.0 or a source build from this repository
+- SandBase Harness v0.3.1 or a source build from this repository
 
 Last verified on 2026-08-14 against DeepSeek Harness commit
 [`47f9438`](https://github.com/deepseek-ai/deepseek-harness/commit/47f943859bef60e4160492346772ded9b24f765a): the Cordis layer composed cleanly,
@@ -17,7 +17,7 @@ DSH launched the stdio child, and the MCP handshake completed.
 Build the tagged source release and expose its two local executables first:
 
 ```bash
-git clone --branch v0.3.0 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.1 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build:runtime


### PR DESCRIPTION
## What changed

- update every user-facing tagged install example from v0.3.0 to v0.3.1
- add a compact first-screen decision table explaining when to choose SandBase Harness
- keep deployment and DeepSeek integration examples aligned with the latest immutable release

## Why

The README badge pointed to v0.3.1 while the primary install path still cloned v0.3.0. That mismatch weakens trust and sends new users to an older release. The new decision table also makes the runtime's differentiation clear before the longer feature list.

## Validation

- `npm run typecheck`
- no remaining `v0.3.0` references in README, docs, or examples
- `git diff --check`