### PR TITLE
docs: add security and contribution policies

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Report a reproducible problem in SandBase Harness
+title: "bug: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: For security vulnerabilities, use the private reporting link in SECURITY.md instead.
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Release, commit, or container tag where the problem occurs.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Provide the smallest reproducible example and exact commands.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior and logs
+      description: Remove secrets, tokens, and personal data.
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node.js version, sandbox provider, and model provider.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## What changed
+
+<!-- Describe the user problem and the focused solution. -->
+
+## Validation
+
+- [ ] `npm run typecheck`
+- [ ] `npm test`
+- [ ] `npm run build`
+- [ ] Documentation or tests were updated when behavior changed
+- [ ] No secrets, credentials, or personal data are included
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+## Our standard
+
+We are committed to a welcoming, respectful, and harassment-free community.
+Be constructive, assume good intent, respect differing experiences, and focus
+feedback on the work. Harassment, discrimination, threats, deliberate
+disruption, and publication of another person's private information are not
+acceptable.
+
+## Enforcement
+
+Maintainers may edit or remove contributions and may temporarily or permanently
+restrict participation when behavior is inappropriate, threatening, or harmful.
+When possible, explain the context and impact without repeating sensitive or
+abusive material. For conduct that violates GitHub's terms, use GitHub's
+[content reporting tools](https://docs.github.com/en/site-policy/acceptable-use-policies/github-appeal-and-reinstatement#reporting-abuse-or-spam).
+
+This policy applies in project spaces and when someone officially represents
+the project elsewhere.
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest released version and to `main`. Please
+upgrade to the latest release before reporting an issue that may already be
+fixed.
+
+## Report a vulnerability privately
+
+Do not open a public issue for a suspected vulnerability. Use
+[GitHub private vulnerability reporting](https://github.com/sandbaseai/sandbase-harness/security/advisories/new)
+so the maintainers can investigate before details are disclosed.
+
+Include the affected version, configuration, reproduction steps, expected
+impact, and any suggested mitigation. Remove credentials, tokens, and personal
+data from the report.
+
+Reports involving sandbox escape, authorization bypass, credential exposure,
+MCP trust boundaries, unsafe command execution, or supply-chain compromise are
+especially useful. We will acknowledge the report when it is triaged and keep
+the reporter informed as a fix and coordinated disclosure plan are developed.
+


### PR DESCRIPTION
## Summary
- document private vulnerability reporting and supported releases
- add a concise project code of conduct
- add structured bug-report and pull-request templates

## Validation
- `git diff --check`
- parsed the issue form as valid YAML
- GitHub private vulnerability reporting is enabled