### PR TITLE
feat(mcp): add container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.managed-agents
+apps
+coverage
+dist
+docs
+examples
+node_modules
+tests
+work
+*.log
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,6 @@ jobs:
 
       - name: Release smoke
         run: npm run smoke:release
+
+      - name: Build MCP container
+        run: docker build -f Dockerfile.mcp -t sandbase-harness-mcp:ci .

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22-bookworm-slim AS build
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.json tsconfig.tests.json tsup.config.ts ./
+COPY src ./src
+RUN npm run build:runtime && npm prune --omit=dev
+
+FROM node:22-bookworm-slim AS runtime
+
+LABEL org.opencontainers.image.title="SandBase Harness MCP" \
+      org.opencontainers.image.description="Six-tool stdio MCP bridge for SandBase Harness sessions" \
+      org.opencontainers.image.source="https://github.com/sandbaseai/sandbase-harness" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      io.modelcontextprotocol.server.name="io.github.sandbaseai/sandbase-harness"
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=build --chown=node:node /app/package.json ./package.json
+COPY --from=build --chown=node:node /app/node_modules ./node_modules
+COPY --from=build --chown=node:node /app/dist ./dist
+
+USER node
+ENTRYPOINT ["node", "dist/mcp/index.js"]
+

--- a/README.md
+++ b/README.md
@@ -111,6 +111,21 @@ official scoped package is announced in this repository, install only from the
 tagged GitHub source release shown above. Do not run `npx managed-agents` or
 `npm install managed-agents`.
 
+The six-tool MCP bridge also has a minimal container definition. Start the
+Harness API, build the image from the tagged source checkout, then add this
+stdio command to an MCP client:
+
+```bash
+docker build -f Dockerfile.mcp -t sandbase-harness-mcp:0.3.1 .
+docker run --rm -i \
+  -e MANAGED_AGENTS_URL=http://host.docker.internal:3000 \
+  sandbase-harness-mcp:0.3.1
+```
+
+For an authenticated remote runtime, also pass `MANAGED_AGENTS_API_KEY`. The
+container image contains only the MCP bridge; agent sessions and sandbox work
+remain in the connected Harness runtime.
+
 For development from the latest `main` branch:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a minimal multi-stage container for the existing six-tool stdio MCP bridge
- run the container as the unprivileged Node user
- include OCI source, license, and MCP namespace labels
- document local build/run with an external Harness API
- build the image in the existing CI release gate

## Validation
- `npm run build:runtime`
- `npx vitest run tests/unit/mcp-server.test.ts tests/integration/mcp.test.ts` (13 passed)
- `git diff --check`
- workflow YAML parse

A local Docker build reached Docker Hub image resolution, but the local daemon received repeated EOF responses from Docker Hub. The PR CI performs the authoritative image build on GitHub infrastructure.

## Scope
This PR does not publish an image or register external metadata. It only adds a reproducible source build and CI validation.