### PR TITLE
chore: release v0.3.2 with containerized MCP bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.3.2 - 2026-08-15
+
+### Highlights
+
+- **Containerized MCP bridge**: adds `Dockerfile.mcp` and `.dockerignore` for
+  the six-tool stdio bridge, with OCI and MCP server metadata.
+- **Verified container build**: CI now builds the production MCP image from a
+  clean checkout so broken Docker packaging blocks future changes.
+- **Release-aligned quick start**: source, Docker, installation, deployment,
+  and DeepSeek Harness examples now pin the immutable v0.3.2 tag that contains
+  every referenced file.
+- **Project trust and discovery**: adds security and contribution policies,
+  private vulnerability reporting, and a direct SandBase Agent Skills link.
+
 ## 0.3.0 - 2026-08-14
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ credentials, audit trails, and a built-in Console — all running on your
 machine or in your own infrastructure.
 
 ```bash
-git clone --branch v0.3.1 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.2 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -94,7 +94,7 @@ the runtime layers used by this integration.
 ## Quick Start
 
 ```bash
-git clone --branch v0.3.1 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.2 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -116,10 +116,10 @@ Harness API, build the image from the tagged source checkout, then add this
 stdio command to an MCP client:
 
 ```bash
-docker build -f Dockerfile.mcp -t sandbase-harness-mcp:0.3.1 .
+docker build -f Dockerfile.mcp -t sandbase-harness-mcp:0.3.2 .
 docker run --rm -i \
   -e MANAGED_AGENTS_URL=http://host.docker.internal:3000 \
-  sandbase-harness-mcp:0.3.1
+  sandbase-harness-mcp:0.3.2
 ```
 
 For an authenticated remote runtime, also pass `MANAGED_AGENTS_API_KEY`. The

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -125,7 +125,7 @@ spec:
     spec:
       containers:
         - name: runtime
-          image: your-registry.example/sandbase-harness:v0.3.1
+          image: your-registry.example/sandbase-harness:v0.3.2
           workingDir: /app
           command:
             - node

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ the tagged GitHub source release and do not run `npx managed-agents` or
 `npm install managed-agents`.
 
 ```bash
-git clone --branch v0.3.1 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.2 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build

--- a/examples/deepseek-harness/README.md
+++ b/examples/deepseek-harness/README.md
@@ -8,7 +8,7 @@ stdio and exposes agents, sessions, streamed turns, artifacts, and cancellation.
 
 - Node.js 22+
 - DeepSeek Harness with `@deepseek-ai/dsh-mcp-client` and stdio MCP support
-- SandBase Harness v0.3.1 or a source build from this repository
+- SandBase Harness v0.3.2 or a source build from this repository
 
 Last verified on 2026-08-14 against DeepSeek Harness commit
 [`47f9438`](https://github.com/deepseek-ai/deepseek-harness/commit/47f943859bef60e4160492346772ded9b24f765a): the Cordis layer composed cleanly,
@@ -17,7 +17,7 @@ DSH launched the stdio child, and the MCP handshake completed.
 Build the tagged source release and expose its two local executables first:
 
 ```bash
-git clone --branch v0.3.1 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.2 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build:runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "managed-agents",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "managed-agents",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "managed-agents",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Local-first, self-hosted AI agent runtime with Claude Managed Agents-style APIs, sandboxed sessions, memory, tools, audit, replay, and a local Console.",
   "type": "module",
   "homepage": "https://github.com/sandbaseai/sandbase-harness#readme",


### PR DESCRIPTION
## Summary

- bump Harness to `0.3.2`
- pin source, Docker, installation, deployment, and DeepSeek Harness examples to the immutable v0.3.2 tag
- document the containerized MCP bridge, Docker CI, security/community policies, and Skills cross-link in the changelog

This fixes a release-consistency issue: main documented `Dockerfile.mcp`, but the referenced v0.3.1 tag predates that file. v0.3.2 will contain every file its quick start references.

## Validation

- `npm run release:check`
  - 76 test files passed, 2 skipped
  - 573 tests passed, 14 skipped
  - typecheck, runtime/console builds, npm dry-run, CLI/workspace smoke all passed
- `git diff --check`
- no stale v0.3.1 references remain outside `package-lock.json`

## Docker note

`Dockerfile.mcp` is unchanged from main and was already validated by CI in #35. Two local rebuild retries reached Docker Hub but failed resolving the official `node:22-bookworm-slim` manifest with a registry EOF; this is recorded as an external registry failure rather than claimed as a successful local build. The PR Docker CI remains the authoritative fresh-checkout gate.