### PR TITLE
docs: connect Harness with portable DSH skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ native `mcp__sandbase__*` tools. See
 [`examples/deepseek-harness`](examples/deepseek-harness/README.md) for the full
 tool list and authenticated-runtime configuration.
 
+Pair the plugin with SandBase Skills to give the same DSH project a portable,
+source-verifiable research workflow:
+
+```bash
+npx --yes github:sandbaseai/sandbase-skills add multi-source-search
+dsh web
+```
+
+This installs the complete Skill into `.dsh/skills/multi-source-search`, DSH's
+project-scoped discovery directory. It runs from GitHub source and needs no
+SandBase account when DSH already provides web/search tools.
+
 New to DSH profiles, plugin composition, tool policy, or session semantics? The
 independent [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook)
 provides source-backed quickstarts, architecture maps, and troubleshooting for

--- a/examples/deepseek-harness/README.md
+++ b/examples/deepseek-harness/README.md
@@ -40,6 +40,22 @@ dsh plugin --profile web add managed-agents
 dsh web
 ```
 
+### Add a portable research Skill
+
+The plugin exposes managed-agent operations as MCP tools. Skills are a separate
+DSH extension surface and can be installed alongside it. From the same DSH
+project root:
+
+```bash
+npx --yes github:sandbaseai/sandbase-skills add multi-source-search
+dsh web
+```
+
+The command copies the complete open-source Skill to
+`.dsh/skills/multi-source-search`. The Skill can use DSH's existing search and
+page-reading tools without a SandBase account; optional provider-backed
+workflows remain opt-in.
+
 For source development, load the included patch directly after building and
 put `dist/mcp` on `PATH`, or replace `command` with the absolute path to the
 built executable in a private test overlay.

--- a/tests/unit/v1-local-first-spec.test.ts
+++ b/tests/unit/v1-local-first-spec.test.ts
@@ -66,4 +66,14 @@ describe('v1 local-first architecture spec', () => {
     expect(settingsPage).toContain('\\"sandbox_provider\\":\\"local\\"');
     expect(settingsPage).not.toContain('\\"hosting_type\\":\\"self_hosted\\"');
   });
+
+  it('documents the companion DSH Skill install path from GitHub source', () => {
+    const command = 'npx --yes github:sandbaseai/sandbase-skills add multi-source-search';
+    const destination = '.dsh/skills/multi-source-search';
+
+    expect(read('README.md')).toContain(command);
+    expect(read('README.md')).toContain(destination);
+    expect(read('examples/deepseek-harness/README.md')).toContain(command);
+    expect(read('examples/deepseek-harness/README.md')).toContain(destination);
+  });
 });


### PR DESCRIPTION
## Summary
- add a runnable SandBase Skills companion workflow to the main DeepSeek Harness section
- explain how the MCP plugin and DSH Skill extension surfaces work together
- document the GitHub-source install destination and no-account host-tool path
- add a regression test for both public integration entry points

## Validation
- `npm run typecheck`
- `npm test` (574 passed, 14 skipped)
- `npm run build`
- `npm_config_cache=/tmp/sandbase-harness-npm-cache npm run package:check`
- `git diff --check`