### PR TITLE
docs: release MiniMax provider guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.3 - 2026-08-19
+
+### Highlights
+
+- **First-class MiniMax provider**: adds MiniMax to Settings V2 and the
+  runtime provider boundary, with global and mainland China endpoints.
+- **Current MiniMax models**: supports `MiniMax-M3` as the default and
+  `MiniMax-M2.7` as an explicit alternative.
+- **Verified setup guide**: documents environment-variable credentials,
+  regional endpoint selection, agent model IDs, and configuration checks.
+
 ## 0.3.2 - 2026-08-15
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ credentials, audit trails, and a built-in Console — all running on your
 machine or in your own infrastructure.
 
 ```bash
-git clone --branch v0.3.2 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.3 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -29,7 +29,7 @@ Choose SandBase Harness when you need more than a model loop:
 | Run generated code safely | Local, Docker, Kubernetes, and self-hosted worker sandboxes |
 | Inspect long-running agents | Persistent sessions, resumable event streams, audit, and replay |
 | Control tool access | MCP toolsets, credential vaults, permission policies, and approvals |
-| Operate any model | OpenAI, Anthropic, and OpenAI-compatible providers, including DeepSeek V4 |
+| Operate any model | OpenAI, Anthropic, MiniMax, and OpenAI-compatible providers, including DeepSeek V4 |
 | Keep infrastructure yours | Local-first SQLite and file storage with no required hosted control plane |
 
 ## Why
@@ -67,7 +67,7 @@ is that runtime layer — not a visual workflow builder and not another model SD
 
 - Node.js 22+
 - npm 10+
-- A model provider API key (OpenAI, Anthropic, or OpenAI-compatible endpoint)
+- A model provider API key (OpenAI, Anthropic, MiniMax, or an OpenAI-compatible endpoint)
 - Docker (optional, for Docker-backed sandboxes)
 
 ## DeepSeek Harness
@@ -108,7 +108,7 @@ the runtime layers used by this integration.
 ## Quick Start
 
 ```bash
-git clone --branch v0.3.2 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.3 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -130,10 +130,10 @@ Harness API, build the image from the tagged source checkout, then add this
 stdio command to an MCP client:
 
 ```bash
-docker build -f Dockerfile.mcp -t sandbase-harness-mcp:0.3.2 .
+docker build -f Dockerfile.mcp -t sandbase-harness-mcp:0.3.3 .
 docker run --rm -i \
   -e MANAGED_AGENTS_URL=http://host.docker.internal:3000 \
-  sandbase-harness-mcp:0.3.2
+  sandbase-harness-mcp:0.3.3
 ```
 
 For an authenticated remote runtime, also pass `MANAGED_AGENTS_API_KEY`. The
@@ -189,6 +189,9 @@ service.
 
 For DeepSeek V4 Pro/Flash configuration, including maximum reasoning effort,
 see [DeepSeek V4](docs/deepseek-v4.md).
+
+For first-class MiniMax configuration, regional endpoints, and the supported
+MiniMax-M3 and MiniMax-M2.7 model IDs, see [MiniMax](docs/minimax.md).
 
 ## CLI
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 Memory、凭证、审计日志、事件回放和可视化 Console 放在同一个运行时边界中，
 并提供原生 DeepSeek Harness stdio MCP 插件。
 
-> 当前稳定版本：[v0.3.2](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.2)
+> 当前稳定版本：[v0.3.3](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.3)
 
 ## 为什么需要它
 
@@ -26,7 +26,7 @@ SandBase Harness 提供这层运行时基础设施。它不是可视化工作流
 - Claude Managed Agents 风格的 /v1 API 和本地 Console
 - SQLite 会话、Agent、Memory、Skill、文件、凭证和 API Key 元数据
 - 可恢复的 Server-Sent Events 与会话事件回放
-- OpenAI、Anthropic 和 OpenAI-compatible 模型边界
+- OpenAI、Anthropic、MiniMax 和 OpenAI-compatible 模型边界
 - Local、Docker、Kubernetes 和自托管 Worker 沙箱
 - MCP Toolset、权限策略、内置工具和 Skill Package
 - DeepSeek Harness 原生 stdio MCP Bridge
@@ -39,7 +39,7 @@ npm 上未加 scope 的 managed-agents **不是**本项目。请使用带标签�
 GitHub 源码，不要运行 npx managed-agents 或 npm install managed-agents。
 
 ~~~bash
-git clone --branch v0.3.2 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.3 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -57,7 +57,7 @@ node ../sandbase-harness/dist/index.js start
 先构建并暴露本地命令：
 
 ~~~bash
-git clone --branch v0.3.2 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.3 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build:runtime
@@ -139,6 +139,7 @@ my-agents/
 - [Skill](./docs/skills.md)
 - [部署示例](./docs/deployment.md)
 - [DeepSeek V4](./docs/deepseek-v4.md)
+- [MiniMax](./docs/minimax.md)
 - [系统设计](./docs/spec/design.md)
 
 ## 开发与验证

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ open-source runtime.
 | Document | Audience | Contents |
 | --- | --- | --- |
 | [Installation](installation.md) | Users and operators | Install options, model configuration, startup flags, and health checks. |
+| [MiniMax](minimax.md) | MiniMax users | Regional endpoints, model IDs, settings, and verification. |
 | [Usage Guide](usage.md) | Users and integrators | Workspace layout, Console workflows, sessions, sandbox backends, resources, credentials, memory, and SDK usage. |
 | [API Reference](api.md) | API and SDK integrators | HTTP endpoints, request shapes, response shapes, errors, and examples. |
 | [Versioned API Matrix](api-matrix.md) | SDK authors and integrators | `/v1` endpoint status, SDK coverage, CLI coverage, and compatibility gaps. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -125,7 +125,7 @@ spec:
     spec:
       containers:
         - name: runtime
-          image: your-registry.example/sandbase-harness:v0.3.2
+          image: your-registry.example/sandbase-harness:v0.3.3
           workingDir: /app
           command:
             - node

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ the tagged GitHub source release and do not run `npx managed-agents` or
 `npm install managed-agents`.
 
 ```bash
-git clone --branch v0.3.2 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.3 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -142,7 +142,7 @@ http://127.0.0.1:3000/dashboard#models
 Configure the workspace model vendor, then click `Validate` or
 `Check configuration` before saving:
 
-- `Vendor`: `anthropic`, `openai`, or `openai_compatible`
+- `Vendor`: `anthropic`, `openai`, `minimax`, or `openai_compatible`
 - `Base URL`: required for OpenAI-compatible local or hosted endpoints
 - `API key`: the provider key for model requests
 
@@ -150,6 +150,9 @@ Runtime model connection settings live in `.managed-agents/config.yaml`. Agents
 set concrete model IDs in their own definitions, for example `model: gpt-4o` or
 `model: openai/gpt-5.5`. The workspace model config supplies provider
 credentials and base URL only.
+
+For MiniMax regional endpoints and supported model IDs, follow the
+[MiniMax configuration guide](minimax.md).
 
 The same file should make the local storage defaults explicit:
 

--- a/docs/minimax.md
+++ b/docs/minimax.md
@@ -1,0 +1,70 @@
+# MiniMax
+
+SandBase Harness v0.3.3 includes a first-class MiniMax provider. The runtime
+uses MiniMax's OpenAI-compatible API while keeping regional endpoint selection
+and supported model IDs explicit.
+
+## Endpoints and models
+
+| Region | OpenAI-compatible base URL |
+| --- | --- |
+| Global | `https://api.minimax.io/v1` |
+| Mainland China | `https://api.minimaxi.com/v1` |
+
+The built-in model IDs are:
+
+- `MiniMax-M3` (default)
+- `MiniMax-M2.7`
+
+Model access can depend on the MiniMax account and plan. Check the current
+[MiniMax text-generation documentation](https://platform.minimax.io/docs/guides/text-generation)
+and [pricing page](https://platform.minimax.io/docs/guides/pricing-paygo) before
+deploying.
+
+## Configure the workspace
+
+Keep the API key outside version control:
+
+```bash
+export MINIMAX_API_KEY=your-key
+```
+
+Start SandBase Harness, open **Settings > Models**, and select **MiniMax**.
+Choose the global or mainland China region, then click **Check configuration**
+before saving.
+
+The equivalent `.managed-agents/config.yaml` section is:
+
+```yaml
+model:
+  vendor: minimax
+  api_key: ${MINIMAX_API_KEY}
+  options:
+    region: global_en
+    model: MiniMax-M3
+```
+
+For the mainland China endpoint, set `region: cn_zh`. An explicit `base_url`
+overrides the built-in regional endpoint when a proxy or gateway is required:
+
+```yaml
+model:
+  vendor: minimax
+  base_url: https://gateway.example/v1
+  api_key: ${MINIMAX_API_KEY}
+  options:
+    region: global_en
+    model: MiniMax-M2.7
+```
+
+Agents can select either supported model directly:
+
+```yaml
+name: MiniMax assistant
+model: MiniMax-M3
+system: You are a helpful assistant.
+```
+
+After saving, create a short session from the Console and inspect its events.
+A successful response verifies the API key, endpoint, model access, and runtime
+path together. Never commit the resolved API key or include it in an issue.

--- a/examples/deepseek-harness/README.md
+++ b/examples/deepseek-harness/README.md
@@ -8,7 +8,7 @@ stdio and exposes agents, sessions, streamed turns, artifacts, and cancellation.
 
 - Node.js 22+
 - DeepSeek Harness with `@deepseek-ai/dsh-mcp-client` and stdio MCP support
-- SandBase Harness v0.3.2 or a source build from this repository
+- SandBase Harness v0.3.3 or a source build from this repository
 
 Last verified on 2026-08-14 against DeepSeek Harness commit
 [`47f9438`](https://github.com/deepseek-ai/deepseek-harness/commit/47f943859bef60e4160492346772ded9b24f765a): the Cordis layer composed cleanly,
@@ -17,7 +17,7 @@ DSH launched the stdio child, and the MCP handshake completed.
 Build the tagged source release and expose its two local executables first:
 
 ```bash
-git clone --branch v0.3.2 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.3 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build:runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "managed-agents",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "managed-agents",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "managed-agents",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Local-first, self-hosted AI agent runtime with Claude Managed Agents-style APIs, sandboxed sessions, memory, tools, audit, replay, and a local Console.",
   "type": "module",
   "homepage": "https://github.com/sandbaseai/sandbase-harness#readme",

--- a/tests/unit/v1-local-first-spec.test.ts
+++ b/tests/unit/v1-local-first-spec.test.ts
@@ -82,10 +82,24 @@ describe('v1 local-first architecture spec', () => {
     const chinese = read('README.zh-CN.md');
 
     expect(root).toContain('[中文](./README.zh-CN.md)');
-    expect(chinese).toContain('git clone --branch v0.3.2 --depth 1');
+    expect(chinese).toContain('git clone --branch v0.3.3 --depth 1');
     expect(chinese).toContain('dsh plugin --profile web add managed-agents');
     expect(chinese).toContain('npx --yes github:sandbaseai/sandbase-skills add multi-source-search');
     expect(chinese).toContain('.dsh/skills/multi-source-search');
     expect(chinese).not.toMatch(/(?:^|\n)npx managed-agents/m);
+  });
+
+  it('documents first-class MiniMax configuration', () => {
+    const readme = read('README.md');
+    const installation = read('docs/installation.md');
+    const minimax = read('docs/minimax.md');
+
+    expect(readme).toContain('[MiniMax](docs/minimax.md)');
+    expect(installation).toContain('`minimax`');
+    expect(minimax).toContain('https://api.minimax.io/v1');
+    expect(minimax).toContain('https://api.minimaxi.com/v1');
+    expect(minimax).toContain('MiniMax-M3');
+    expect(minimax).toContain('MiniMax-M2.7');
+    expect(minimax).toContain('${MINIMAX_API_KEY}');
   });
 });


### PR DESCRIPTION
## Summary
- publish first-class MiniMax setup guidance for global and mainland China endpoints
- document MiniMax-M3 and MiniMax-M2.7 configuration and verification
- prepare the v0.3.3 source release and align pinned examples
- add documentation regression coverage

## Validation
- npm run release:check
- 76 test files passed, 579 tests passed, 14 skipped
- runtime and Console production builds passed
- npm package dry-run and release smoke passed

This documents the MiniMax runtime support merged in #19.