### PR TITLE
ci: publish MCP container releases

### DIFF
--- a/.github/workflows/publish-mcp-image.yml
+++ b/.github/workflows/publish-mcp-image.yml
@@ -1,0 +1,61 @@
+name: Publish MCP Image
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish multi-platform MCP image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-qemu-action@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: metadata
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/sandbaseai/sandbase-harness-mcp
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+          labels: |
+            io.modelcontextprotocol.server.name=io.github.sandbaseai/sandbase-harness
+
+      - name: Build and push image
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.mcp
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ghcr.io/sandbaseai/sandbase-harness-mcp
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.4 - 2026-08-19
+
+### Highlights
+
+- **Published MCP container**: release tags now produce public multi-platform
+  `linux/amd64` and `linux/arm64` images in GitHub Container Registry.
+- **Verifiable supply chain**: images carry OCI and MCP ownership labels and a
+  GitHub build-provenance attestation tied to the release digest.
+- **Registry-ready metadata**: adds a version-aligned `server.json` for the
+  official MCP Registry OCI distribution format.
+
 ## 0.3.3 - 2026-08-19
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ credentials, audit trails, and a built-in Console — all running on your
 machine or in your own infrastructure.
 
 ```bash
-git clone --branch v0.3.3 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.4 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -108,7 +108,7 @@ the runtime layers used by this integration.
 ## Quick Start
 
 ```bash
-git clone --branch v0.3.3 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.4 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -125,20 +125,21 @@ official scoped package is announced in this repository, install only from the
 tagged GitHub source release shown above. Do not run `npx managed-agents` or
 `npm install managed-agents`.
 
-The six-tool MCP bridge also has a minimal container definition. Start the
-Harness API, build the image from the tagged source checkout, then add this
-stdio command to an MCP client:
+The six-tool MCP bridge is published as a multi-architecture OCI image. Start
+the Harness API, then add this stdio command to an MCP client:
 
 ```bash
-docker build -f Dockerfile.mcp -t sandbase-harness-mcp:0.3.3 .
+docker pull ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4
 docker run --rm -i \
   -e MANAGED_AGENTS_URL=http://host.docker.internal:3000 \
-  sandbase-harness-mcp:0.3.3
+  ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4
 ```
 
 For an authenticated remote runtime, also pass `MANAGED_AGENTS_API_KEY`. The
 container image contains only the MCP bridge; agent sessions and sandbox work
-remain in the connected Harness runtime.
+remain in the connected Harness runtime. Every release image is built from the
+matching Git tag for `linux/amd64` and `linux/arm64`, includes OCI source and
+MCP ownership metadata, and receives a GitHub build-provenance attestation.
 
 For development from the latest `main` branch:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 Memory、凭证、审计日志、事件回放和可视化 Console 放在同一个运行时边界中，
 并提供原生 DeepSeek Harness stdio MCP 插件。
 
-> 当前稳定版本：[v0.3.3](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.3)
+> 当前稳定版本：[v0.3.4](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.4)
 
 ## 为什么需要它
 
@@ -39,7 +39,7 @@ npm 上未加 scope 的 managed-agents **不是**本项目。请使用带标签�
 GitHub 源码，不要运行 npx managed-agents 或 npm install managed-agents。
 
 ~~~bash
-git clone --branch v0.3.3 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.4 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -57,7 +57,7 @@ node ../sandbase-harness/dist/index.js start
 先构建并暴露本地命令：
 
 ~~~bash
-git clone --branch v0.3.3 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.4 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build:runtime

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -125,7 +125,7 @@ spec:
     spec:
       containers:
         - name: runtime
-          image: your-registry.example/sandbase-harness:v0.3.3
+          image: your-registry.example/sandbase-harness:v0.3.4
           workingDir: /app
           command:
             - node

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ the tagged GitHub source release and do not run `npx managed-agents` or
 `npm install managed-agents`.
 
 ```bash
-git clone --branch v0.3.3 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.4 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build

--- a/examples/deepseek-harness/README.md
+++ b/examples/deepseek-harness/README.md
@@ -8,7 +8,7 @@ stdio and exposes agents, sessions, streamed turns, artifacts, and cancellation.
 
 - Node.js 22+
 - DeepSeek Harness with `@deepseek-ai/dsh-mcp-client` and stdio MCP support
-- SandBase Harness v0.3.3 or a source build from this repository
+- SandBase Harness v0.3.4 or a source build from this repository
 
 Last verified on 2026-08-14 against DeepSeek Harness commit
 [`47f9438`](https://github.com/deepseek-ai/deepseek-harness/commit/47f943859bef60e4160492346772ded9b24f765a): the Cordis layer composed cleanly,
@@ -17,7 +17,7 @@ DSH launched the stdio child, and the MCP handshake completed.
 Build the tagged source release and expose its two local executables first:
 
 ```bash
-git clone --branch v0.3.3 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.4 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build:runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "managed-agents",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "managed-agents",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "managed-agents",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Local-first, self-hosted AI agent runtime with Claude Managed Agents-style APIs, sandboxed sessions, memory, tools, audit, replay, and a local Console.",
   "type": "module",
   "homepage": "https://github.com/sandbaseai/sandbase-harness#readme",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.sandbaseai/sandbase-harness",
+  "title": "SandBase Harness",
+  "description": "Stdio MCP bridge for SandBase Harness agents, sessions, turns, artifacts, and cancellation.",
+  "repository": {
+    "url": "https://github.com/sandbaseai/sandbase-harness",
+    "source": "github"
+  },
+  "version": "0.3.4",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "MANAGED_AGENTS_URL",
+          "description": "URL of the SandBase Harness runtime API.",
+          "isRequired": true,
+          "isSecret": false,
+          "format": "string"
+        },
+        {
+          "name": "MANAGED_AGENTS_API_KEY",
+          "description": "API key when the connected Harness runtime requires authentication.",
+          "isRequired": false,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit/mcp-distribution.test.ts
+++ b/tests/unit/mcp-distribution.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const read = (path: string): string => readFileSync(path, 'utf8');
+
+describe('MCP OCI distribution', () => {
+  it('keeps the registry document aligned with the release version and image', () => {
+    const packageManifest = JSON.parse(read('package.json')) as { version: string };
+    const server = JSON.parse(read('server.json')) as {
+      name: string;
+      version: string;
+      packages: Array<{ registryType: string; identifier: string; transport: { type: string } }>;
+    };
+
+    expect(server.name).toBe('io.github.sandbaseai/sandbase-harness');
+    expect(server.version).toBe(packageManifest.version);
+    expect(server.packages).toHaveLength(1);
+    expect(server.packages[0]).toEqual(expect.objectContaining({
+      registryType: 'oci',
+      identifier: `ghcr.io/sandbaseai/sandbase-harness-mcp:${packageManifest.version}`,
+      transport: { type: 'stdio' },
+    }));
+  });
+
+  it('publishes release images with package permissions and provenance', () => {
+    const workflow = read('.github/workflows/publish-mcp-image.yml');
+    const dockerfile = read('Dockerfile.mcp');
+
+    expect(workflow).toContain('types: [published]');
+    expect(workflow).toContain('packages: write');
+    expect(workflow).toContain('platforms: linux/amd64,linux/arm64');
+    expect(workflow).toContain('actions/attest-build-provenance@v4');
+    expect(workflow).not.toContain('npm publish');
+    expect(dockerfile).toContain('io.modelcontextprotocol.server.name="io.github.sandbaseai/sandbase-harness"');
+  });
+});

--- a/tests/unit/v1-local-first-spec.test.ts
+++ b/tests/unit/v1-local-first-spec.test.ts
@@ -82,7 +82,7 @@ describe('v1 local-first architecture spec', () => {
     const chinese = read('README.zh-CN.md');
 
     expect(root).toContain('[中文](./README.zh-CN.md)');
-    expect(chinese).toContain('git clone --branch v0.3.3 --depth 1');
+    expect(chinese).toContain('git clone --branch v0.3.4 --depth 1');
     expect(chinese).toContain('dsh plugin --profile web add managed-agents');
     expect(chinese).toContain('npx --yes github:sandbaseai/sandbase-skills add multi-source-search');
     expect(chinese).toContain('.dsh/skills/multi-source-search');


### PR DESCRIPTION
## Summary
- publish the six-tool MCP bridge to GHCR for linux/amd64 and linux/arm64 on each GitHub Release
- attach OCI/MCP ownership metadata and GitHub build-provenance attestations
- add a version-aligned MCP Registry server.json using the OCI distribution
- prepare v0.3.4 docs and immutable install commands

## Validation
- npm run release:check
- 77 test files passed, 581 tests passed, 14 skipped
- runtime and Console production builds passed
- package dry-run and release smoke passed
- mcp-publisher v1.8.1 validate: server.json is valid
- workflow YAML parse and targeted distribution tests passed

## Distribution boundary
- does not publish npm
- image contains only the stdio MCP bridge; sessions and sandbox work remain in the connected Harness runtime