### PR TITLE
ci: publish official MCP registry metadata

### DIFF
--- a/.github/workflows/publish-mcp-image.yml
+++ b/.github/workflows/publish-mcp-image.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   packages: write
   attestations: write
+  artifact-metadata: write
   id-token: write
 
 jobs:
@@ -36,7 +37,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
           labels: |
             io.modelcontextprotocol.server.name=io.github.sandbaseai/sandbase-harness
 

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,47 @@
+name: Publish MCP Registry Metadata
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-mcp-registry
+  cancel-in-progress: false
+
+env:
+  MCP_PUBLISHER_VERSION: v1.8.1
+  MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
+
+jobs:
+  publish:
+    name: Validate and publish registry metadata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Verify the public release image exists
+        run: |
+          IMAGE=$(jq -r '.packages[0].identifier' server.json)
+          test -n "$IMAGE"
+          docker manifest inspect "$IMAGE"
+
+      - name: Install verified MCP publisher
+        run: |
+          ARCHIVE=mcp-publisher_linux_amd64.tar.gz
+          curl --fail --location --silent --show-error \
+            --output "$ARCHIVE" \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/${ARCHIVE}"
+          echo "${MCP_PUBLISHER_SHA256}  ${ARCHIVE}" | sha256sum --check --strict
+          tar -xzf "$ARCHIVE" mcp-publisher
+
+      - name: Validate registry metadata
+        run: ./mcp-publisher validate
+
+      - name: Authenticate with GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to the official MCP Registry
+        run: ./mcp-publisher publish

--- a/tests/unit/mcp-distribution.test.ts
+++ b/tests/unit/mcp-distribution.test.ts
@@ -28,9 +28,24 @@ describe('MCP OCI distribution', () => {
 
     expect(workflow).toContain('types: [published]');
     expect(workflow).toContain('packages: write');
+    expect(workflow).toContain('artifact-metadata: write');
     expect(workflow).toContain('platforms: linux/amd64,linux/arm64');
     expect(workflow).toContain('actions/attest-build-provenance@v4');
     expect(workflow).not.toContain('npm publish');
     expect(dockerfile).toContain('io.modelcontextprotocol.server.name="io.github.sandbaseai/sandbase-harness"');
+  });
+
+  it('publishes validated metadata through short-lived GitHub OIDC', () => {
+    const workflow = read('.github/workflows/publish-mcp-registry.yml');
+
+    expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).toContain('id-token: write');
+    expect(workflow).toContain('docker manifest inspect');
+    expect(workflow).toContain('sha256sum --check --strict');
+    expect(workflow).toContain('./mcp-publisher validate');
+    expect(workflow).toContain('./mcp-publisher login github-oidc');
+    expect(workflow).toContain('./mcp-publisher publish');
+    expect(workflow).not.toContain('NPM_TOKEN');
+    expect(workflow).not.toContain('MCP_GITHUB_TOKEN');
   });
 });


### PR DESCRIPTION
## Summary
- add a manually dispatched official MCP Registry publication job
- authenticate with short-lived GitHub OIDC; no PAT, registry secret, or npm token
- require the public OCI image to resolve before metadata publication
- pin and checksum-verify mcp-publisher v1.8.1
- add the new artifact-metadata permission requested by the provenance action
- remove the duplicate latest tag declaration

## Validation
- both workflow files parse as YAML
- MCP distribution regression tests pass
- server.json already passes mcp-publisher v1.8.1 online validation
- v0.3.4 OCI image is anonymously accessible for amd64 and arm64

## Security boundary
- workflow_dispatch only
- read-only repository access plus ephemeral id-token permission
- no npm publication and no persistent publishing credential