### PR TITLE
docs: show official MCP Registry status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![GitHub stars](https://img.shields.io/github/stars/sandbaseai/sandbase-harness?style=social)](https://github.com/sandbaseai/sandbase-harness/stargazers)
 [![Release](https://img.shields.io/github/v/release/sandbaseai/sandbase-harness)](https://github.com/sandbaseai/sandbase-harness/releases/latest)
+[![Official MCP Registry](https://img.shields.io/badge/Official_MCP_Registry-active-2ea44f)](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.sandbaseai%2Fsandbase-harness)
 [![Discussions](https://img.shields.io/github/discussions/sandbaseai/sandbase-harness)](https://github.com/sandbaseai/sandbase-harness/discussions)
 [![License](https://img.shields.io/github/license/sandbaseai/sandbase-harness)](LICENSE)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,6 +8,8 @@ Memory、凭证、审计日志、事件回放和可视化 Console 放在同一�
 
 > 当前稳定版本：[v0.3.4](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.4)
 
+> 官方 MCP Registry：[io.github.sandbaseai/sandbase-harness](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.sandbaseai%2Fsandbase-harness)（状态：`active`）
+
 > 如果只需要轻量接入而不需要完整 Runtime，可使用 [SandBase CLI](https://github.com/sandbaseai/cli)：
 > 它通过本地 stdio MCP Bridge，将 25 个 AI 客户端目标连接到 2,000+ 模型。
 


### PR DESCRIPTION
## Summary

Expose the existing official MCP Registry publication on the repository landing page:

- add an `Official MCP Registry: active` badge to the English README
- add the verified registry entry and status to the Chinese README

## Verification

- Official registry query returns exactly one result for `io.github.sandbaseai/sandbase-harness`
- Registry metadata reports `status: active` and `isLatest: true`
- Badge endpoint returns HTTP 200
- `git diff --check` passes

The MCP Registry publication itself is unchanged; this PR only makes the already-live authoritative listing visible to repository visitors.