### PR TITLE
feat: add portable Harness MCP plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,25 @@ remain in the connected Harness runtime. Every release image is built from the
 matching Git tag for `linux/amd64` and `linux/arm64`, includes OCI source and
 MCP ownership metadata, and receives a GitHub build-provenance attestation.
 
+### Portable Agent Plugin
+
+Copilot CLI, VS Code, and other Agent Plugins 1.0 clients can install the same
+OCI-backed MCP bridge directly from this repository. Start the Harness API and
+Docker first, then expose its URL to the plugin process:
+
+```bash
+export MANAGED_AGENTS_URL=http://host.docker.internal:3000
+# Optional when the runtime requires authentication:
+export MANAGED_AGENTS_API_KEY=your-runtime-key
+
+copilot plugin install sandbaseai/sandbase-harness:agent-plugin
+```
+
+The plugin passes these environment variables through to the pinned
+`ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4` image. It does not store a key
+in `plugin.json`, `mcp.json`, or the installed plugin files. On Linux, the
+plugin's Docker command maps `host.docker.internal` through `host-gateway`.
+
 For development from the latest `main` branch:
 
 ```bash

--- a/agent-plugin/mcp.json
+++ b/agent-plugin/mcp.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "sandbase-harness": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "--add-host=host.docker.internal:host-gateway",
+        "-e",
+        "MANAGED_AGENTS_URL",
+        "-e",
+        "MANAGED_AGENTS_API_KEY",
+        "ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4"
+      ]
+    }
+  }
+}

--- a/agent-plugin/plugin.json
+++ b/agent-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "sandbase-harness",
+  "version": "0.1.0",
+  "description": "Connect Copilot and compatible agents to an existing SandBase Harness runtime for agents, sessions, turns, artifacts, and cancellation.",
+  "author": {
+    "name": "SandBase AI",
+    "url": "https://github.com/sandbaseai"
+  },
+  "homepage": "https://github.com/sandbaseai/sandbase-harness",
+  "repository": "https://github.com/sandbaseai/sandbase-harness",
+  "license": "Apache-2.0",
+  "keywords": [
+    "agent-runtime",
+    "mcp",
+    "sandbox",
+    "self-hosted"
+  ]
+}

--- a/tests/unit/mcp-distribution.test.ts
+++ b/tests/unit/mcp-distribution.test.ts
@@ -48,4 +48,41 @@ describe('MCP OCI distribution', () => {
     expect(workflow).not.toContain('NPM_TOKEN');
     expect(workflow).not.toContain('MCP_GITHUB_TOKEN');
   });
+
+  it('ships a portable Agent Plugin pinned to the release MCP image', () => {
+    const packageManifest = JSON.parse(read('package.json')) as { version: string };
+    const plugin = JSON.parse(read('agent-plugin/plugin.json')) as {
+      $schema: string;
+      name: string;
+      version: string;
+      license: string;
+    };
+    const mcp = JSON.parse(read('agent-plugin/mcp.json')) as {
+      $schema: string;
+      mcpServers: Record<string, {
+        type: string;
+        command: string;
+        args: string[];
+        env?: Record<string, string>;
+      }>;
+    };
+    const server = mcp.mcpServers['sandbase-harness'];
+
+    expect(plugin).toEqual(expect.objectContaining({
+      $schema: 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json',
+      name: 'sandbase-harness',
+      version: '0.1.0',
+      license: 'Apache-2.0',
+    }));
+    expect(mcp.$schema).toBe('https://agent-plugins.org/schemas/1.0.0/mcp.schema.json');
+    expect(server).toEqual(expect.objectContaining({
+      type: 'stdio',
+      command: 'docker',
+    }));
+    expect(server.args).toContain(`ghcr.io/sandbaseai/sandbase-harness-mcp:${packageManifest.version}`);
+    expect(server.args).toContain('MANAGED_AGENTS_URL');
+    expect(server.args).toContain('MANAGED_AGENTS_API_KEY');
+    expect(server.env).toBeUndefined();
+    expect(JSON.stringify(mcp)).not.toMatch(/api[_-]?key["']?\s*:/i);
+  });
 });


### PR DESCRIPTION
## What changed

- add a portable Agent Plugins 1.0 package under `agent-plugin/`
- configure the released Harness MCP OCI bridge through standard `mcp.json`
- forward runtime URL and optional API key from the user's environment without storing secrets
- document direct Copilot CLI installation and Linux host-gateway behavior
- test schema identity, image-version pinning, transport, and secret posture

## Why

Harness already publishes an active official MCP Registry entry and a multi-architecture OCI stdio bridge. This packages that bridge for Agent Plugins-compatible clients, so users can install the integration directly from the repository while keeping the Harness runtime and data in their own infrastructure.

## Validation

- official Agent Plugins 1.0 `plugin.json` Schema: valid
- official Agent Plugins 1.0 `mcp.json` Schema: valid
- OCI manifest resolves for `ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4`
- `npm run typecheck`
- `npm test` — 582 passed, 15 skipped
- `git diff --check`

AI assistance was used to implement and validate this contribution.
