### PR TITLE
docs: add DSH Plugin Store to SandBase ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,9 @@ init smoke, and `examples/basic` startup smoke.
 - [SandBase CLI](https://github.com/sandbaseai/cli) — connect Cursor, Claude Code,
   Codex, Windsurf, Gemini CLI, OpenCode, and other MCP clients to 2,000+ AI
   models with one onboarding command.
+- [DSH Plugin Store](https://github.com/sandbaseai/dsh-plugin-store) — discover,
+  filter, install, and manage community DeepSeek Harness plugins from the native
+  Settings experience.
 - [SandBase](https://www.sandbase.ai) — hosted agent infrastructure, model access,
   tools, and managed sandboxes.
 


### PR DESCRIPTION
## Summary

Add DSH Plugin Store to the existing SandBase Ecosystem section.

The link is relevant to this repository because SandBase Harness already documents its DeepSeek Harness integration, while the Store provides native discovery and management for the surrounding plugin ecosystem.

## Scope

- README-only change
- no runtime or dependency changes
- links to the Sandbase organization repository

Launch discussion: https://github.com/sandbaseai/dsh-plugin-store/discussions/5