### PR TITLE
docs: link independent self-hosting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,13 @@ init smoke, and `examples/basic` startup smoke.
 - [Contributing](CONTRIBUTING.md)
 - [Changelog](CHANGELOG.md)
 
+## Community Guides
+
+- [Self-host the SandBase agent runtime](https://www.ssdnodes.com/learn/self-host-sandbase-agent-runtime)
+  by SSD Nodes — an independent VPS walkthrough covering installation, agent
+  configuration, MCP servers, sandbox modes, and reverse-proxy deployment. The
+  article demonstrates v0.3.2; use the current release command above for v0.3.4.
+
 ## License
 
 [Apache-2.0](LICENSE)


### PR DESCRIPTION
## What changed

- add a Community Guides section to the README
- link SSD Nodes' independent SandBase Harness self-hosting walkthrough
- disclose that the article demonstrates v0.3.2 and point readers to the current v0.3.4 command

## Why

The guide is new third-party coverage with a practical VPS deployment path. Linking it gives visitors independent implementation evidence while the explicit version note prevents stale install instructions from being mistaken for the current release.

## Validation

- external guide returns HTTP 200
- `git diff --check`
- `npm test -- --run`: 77 files passed, 582 tests passed; 2 files / 15 tests skipped by their existing environment gates

Documentation only; no runtime behavior changed.