### PR TITLE
docs: link DeepSeek Harness operator tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,11 @@ sandboxed execution, credentials, audit, and replay, read
 New to DSH profiles, plugin composition, tool policy, or session semantics? The
 independent [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook)
 provides source-backed quickstarts, architecture maps, and troubleshooting for
-the runtime layers used by this integration.
+the runtime layers used by this integration. Start with the local-browser
+[Install Doctor](https://sandbaseai.github.io/deepseek-harness-handbook/install-doctor.html)
+for installation evidence, or use the
+[Failure Router](https://sandbaseai.github.io/deepseek-harness-handbook/diagnose.html)
+to identify the first broken runtime boundary.
 
 ## Quick Start
 


### PR DESCRIPTION
## What changed

Extends the existing DeepSeek Harness Handbook paragraph with direct routes to:

- the local-browser Install Doctor for installation evidence
- the Failure Router for identifying the first broken runtime boundary

## Why

The repository already ships a native DSH plugin and already references the Handbook. Direct task links make that existing integration documentation actionable without adding a second promotional section.

## Verification

- both destinations return HTTP 200
- `npm run format:check`
- `git diff --check`
- one README-only change