### PR TITLE
docs: add focused star call to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Choose SandBase Harness when you need more than a model loop:
 | Operate any model | OpenAI, Anthropic, MiniMax, and OpenAI-compatible providers, including DeepSeek V4 |
 | Keep infrastructure yours | Local-first SQLite and file storage with no required hosted control plane |
 
+If this runtime solves a real agent-infrastructure problem for you,
+[star the repository](https://github.com/sandbaseai/sandbase-harness) so other builders can find it.
+
 ## Why
 
 Agent SDKs handle the model loop. Production agents need more: persistent

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,6 +28,9 @@ Memory、凭证、审计日志、事件回放和可视化 Console 放在同一�
 SandBase Harness 提供这层运行时基础设施。它不是可视化工作流编辑器，
 也不替代模型 SDK。
 
+如果它解决了你的真实 Agent 基础设施问题，欢迎
+[为仓库点 Star](https://github.com/sandbaseai/sandbase-harness)，帮助更多开发者发现它。
+
 ## 核心能力
 
 - Claude Managed Agents 风格的 /v1 API 和本地 Console


### PR DESCRIPTION
## Summary

Add one restrained call to action immediately after the value proposition in both English and Chinese READMEs.

The wording asks for a star only when Harness solves a real infrastructure problem and explains that the signal helps other builders discover the project.

## Validation

- English and Chinese placement are parallel
- `git diff --check` passes
- no runtime or package files changed