### PR TITLE
docs: add Stars badge to Chinese README

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,6 +2,8 @@
 
 [English](./README.md) | 中文
 
+[![GitHub stars](https://img.shields.io/github/stars/sandbaseai/sandbase-harness?style=social)](https://github.com/sandbaseai/sandbase-harness/stargazers)
+
 一个本地优先、可自托管的 AI Agent Runtime。它把持久化会话、沙箱工具、
 Memory、凭证、审计日志、事件回放和可视化 Console 放在同一个运行时边界中，
 并提供原生 DeepSeek Harness stdio MCP 插件。


### PR DESCRIPTION
## Summary

- add the existing GitHub Stars badge to the Chinese README header
- give Chinese-language visitors the same first-screen repository signal and stargazers link as the English README
- keep the existing conditional, usage-first Star call to action unchanged

## Validation

- reused the exact badge URL and target already present in `README.md`
- `git diff --check`
