### PR TITLE
docs: link bilingual DSH runtime guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ native `mcp__sandbase__*` tools. See
 [`examples/deepseek-harness`](examples/deepseek-harness/README.md) for the full
 tool list and authenticated-runtime configuration.
 
+For a walkthrough that starts with DSH and adds this runtime as a real
+third-party plugin, read the
+[DeepSeek Harness developer guide](https://blog.sandbase.ai/deepseek-harness-developer-preview-2026/#add-a-real-third-party-runtime-plugin).
+
 Pair the plugin with SandBase Skills to give the same DSH project a portable,
 source-verifiable research workflow:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,6 +99,9 @@ DSH 随后可以通过原生 MCP Namespace：
 完整工具列表、兼容性证据、权限边界和卸载方法见
 [DeepSeek Harness 集成指南](./examples/deepseek-harness/README.md)。
 
+如果希望从 DSH 开始，按步骤加入这个第三方 Runtime 插件，请阅读
+[DeepSeek Harness 开发者指南](https://blog.sandbase.ai/zh-CN/deepseek-harness-developer-preview-2026/#接入一个真实的第三方-runtime-插件)。
+
 官方社区展示：
 [DeepSeek Harness Discussion #1918](https://github.com/deepseek-ai/deepseek-harness/discussions/1918)。
 


### PR DESCRIPTION
## Summary

- link the new English DSH runtime-plugin walkthrough from the Harness integration section
- add the equivalent Chinese guide link to the localized README
- target the exact rendered section anchors so readers land on the reproducible v0.3.4 workflow

## Verification

- both public article pages return successfully
- the rendered Chinese heading ID is `接入一个真实的第三方-runtime-插件`
- both README links contain the deployed article slug
- `git diff --check`
