### PR TITLE
docs: add Codespaces quick start

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "SandBase Harness",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22-bookworm",
+  "postCreateCommand": "npm ci && npm run build",
+  "forwardPorts": [3000],
+  "portsAttributes": {
+    "3000": {
+      "label": "SandBase Harness Console",
+      "onAutoForward": "notify"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ Choose SandBase Harness when you need more than a model loop:
 If this runtime solves a real agent-infrastructure problem for you,
 [star the repository](https://github.com/sandbaseai/sandbase-harness) so other builders can find it.
 
+### Try it in Codespaces
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sandbaseai/sandbase-harness?quickstart=1)
+
+The included development container installs dependencies and builds the runtime.
+When the terminal is ready, start the server on the forwarded port:
+
+```bash
+node dist/index.js start --host 0.0.0.0
+```
+
+Open the forwarded **SandBase Harness Console** port, then configure a model in
+**Settings > Models**. Codespaces usage may be billed by GitHub; the local
+quick start below remains free and keeps all runtime data on your machine.
+
 ## Why
 
 Agent SDKs handle the model loop. Production agents need more: persistent

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,6 +33,20 @@ SandBase Harness 提供这层运行时基础设施。它不是可视化工作流
 如果它解决了你的真实 Agent 基础设施问题，欢迎
 [为仓库点 Star](https://github.com/sandbaseai/sandbase-harness)，帮助更多开发者发现它。
 
+### 在 Codespaces 中试用
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sandbaseai/sandbase-harness?quickstart=1)
+
+仓库内置的开发容器会自动安装依赖并构建运行时。终端准备完成后，在转发端口上启动服务：
+
+```bash
+node dist/index.js start --host 0.0.0.0
+```
+
+打开转发的 **SandBase Harness Console** 端口，然后在 **Settings > Models**
+中配置模型。GitHub 可能会对 Codespaces 用量计费；下方的本地快速开始仍然免费，
+并会把全部运行时数据保存在你的机器上。
+
 ## 核心能力
 
 - Claude Managed Agents 风格的 /v1 API 和本地 Console


### PR DESCRIPTION
## Summary
- add a Node 22 development container that installs and builds the runtime
- expose the Console port with a clear label
- add English and Chinese Codespaces quick-start instructions and cost disclosure

## Verification
- `npm run typecheck`
- `npm test` (583 passed, 14 skipped)
- `npm run build`
- runtime health endpoint returned `healthy`
- `git diff --check`