### PR TITLE
feat: expose Agent Skill compatibility

### DIFF
--- a/apps/console/src/components/pages/BuildPages.tsx
+++ b/apps/console/src/components/pages/BuildPages.tsx
@@ -19,7 +19,8 @@ export function Skills({ data, onRefresh }: { data: ConsoleData; onRefresh: () =
         || skill.id.toLowerCase().includes(q)
         || skill.name.toLowerCase().includes(q)
         || skillDisplayName(skill).toLowerCase().includes(q)
-        || skill.description.toLowerCase().includes(q);
+        || skill.description.toLowerCase().includes(q)
+        || skill.compatibility?.toLowerCase().includes(q);
       return sourceMatches && queryMatches;
     });
   }, [data.skills, query, source]);
@@ -124,6 +125,12 @@ function SkillDetailsDrawer({ skill, onClose }: { skill: Skill; onClose: () => v
       </div>
       <div className="drawerBody">
         <p>{skill.description}</p>
+        {skill.compatibility ? (
+          <div className="infoBanner">
+            <strong>Compatibility</strong>
+            <span>{skill.compatibility}</span>
+          </div>
+        ) : null}
         <div className="drawerMetaGrid">
           <span>Source</span>
           <strong>{skill.source === 'anthropic' ? 'Anthropic' : 'Custom'}</strong>

--- a/apps/console/src/components/pages/settings/api-reference/skills.json
+++ b/apps/console/src/components/pages/settings/api-reference/skills.json
@@ -54,6 +54,11 @@
         "name": "source",
         "type": "custom | anthropic",
         "description": "Skill origin."
+      },
+      {
+        "name": "compatibility",
+        "type": "string | null",
+        "description": "Authored Agent Skills environment requirements; descriptive only and never executed."
       }
     ]
   },

--- a/apps/console/src/types.ts
+++ b/apps/console/src/types.ts
@@ -215,6 +215,7 @@ export type Skill = {
   name: string;
   display_title: string | null;
   description: string;
+  compatibility: string | null;
   source: 'custom' | 'anthropic';
   latest_version: string | null;
   versions: Array<{ id: string; created_at: string | null; latest: boolean }>;

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -29,12 +29,15 @@ The total upload size limit is 8 MB.
 ## SKILL.md
 
 `SKILL.md` must start with YAML frontmatter. `name` and `description` are
-required.
+required. The optional standard `compatibility` field describes concrete host,
+system-package, network, or runtime requirements and is limited to 500
+characters.
 
 ```markdown
 ---
 name: code-review-assistant
 description: Reviews code changes for correctness, security, and maintainability.
+compatibility: Requires git and access to the source repository.
 ---
 
 # Code Review Assistant
@@ -134,9 +137,15 @@ Response:
   "type": "skill",
   "updated_at": "2026-07-12T00:00:00.000Z",
   "name": "code-review-assistant",
-  "description": "Reviews code changes."
+  "description": "Reviews code changes.",
+  "compatibility": "Requires git and access to the source repository."
 }
 ```
+
+The API and Console expose `compatibility` before an operator assigns the Skill
+to an agent. SandBase Harness treats this field as untrusted descriptive text;
+it does not install packages, grant permissions, or enable network access from
+its contents.
 
 ## List And Retrieve Skills
 

--- a/src/api/routes/skill-resources.ts
+++ b/src/api/routes/skill-resources.ts
@@ -21,6 +21,7 @@ export function skillResource(skill: Skill) {
     updated_at: skill.updated_at,
     name: skill.name,
     description: skill.description,
+    compatibility: skill.compatibility,
     file: skill.file || null,
     versions: skill.versions,
   };

--- a/src/core/skills/catalog.ts
+++ b/src/core/skills/catalog.ts
@@ -44,6 +44,7 @@ function builtinSkill(input: {
     name: input.id,
     display_title: input.id,
     description: input.description,
+    compatibility: null,
     instructions: '',
     frontmatter: {},
     file: '',

--- a/src/core/skills/loader.ts
+++ b/src/core/skills/loader.ts
@@ -33,6 +33,8 @@ export interface Skill {
   display_title: string | null;
   /** Short description (from frontmatter `description`). */
   description: string;
+  /** Optional Agent Skills environment requirements. */
+  compatibility: string | null;
   /** Markdown body - the instructions the model should follow. */
   instructions: string;
   /** Original frontmatter (preserved for round-trip). */
@@ -96,6 +98,10 @@ export function parseSkill(content: string, packageName: string, file = `${packa
   if (!name || !description) {
     return null;
   }
+  const compatibility = readCompatibility(frontmatter);
+  if (frontmatter.compatibility !== undefined && compatibility === null) {
+    return null;
+  }
 
   const displayTitle = typeof frontmatter.display_title === 'string' && frontmatter.display_title.trim()
     ? frontmatter.display_title.trim()
@@ -107,6 +113,7 @@ export function parseSkill(content: string, packageName: string, file = `${packa
     name,
     display_title: displayTitle,
     description,
+    compatibility,
     instructions: (match[2] ?? '').trim(),
     frontmatter,
     file,
@@ -246,4 +253,9 @@ function readSkillMetadata(skillDir: string): SkillMetadata | null {
 
 function readString(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function readCompatibility(frontmatter: Record<string, unknown>): string | null {
+  const compatibility = readString(frontmatter.compatibility);
+  return compatibility && compatibility.length <= 500 ? compatibility : null;
 }

--- a/src/core/skills/store.ts
+++ b/src/core/skills/store.ts
@@ -72,14 +72,16 @@ export function getSkillStoragePath(db: Database, id: string): string | null {
 }
 
 function rowToSkill(row: SkillRow): Skill {
+  const frontmatter = parseObject(row.frontmatter);
   return {
     id: row.id,
     type: 'skill',
     name: row.name,
     display_title: row.display_title,
     description: row.description,
+    compatibility: compatibilityFromFrontmatter(frontmatter),
     instructions: row.instructions,
-    frontmatter: parseObject(row.frontmatter),
+    frontmatter,
     file: row.file,
     source: row.source,
     latest_version: row.latest_version,
@@ -87,6 +89,13 @@ function rowToSkill(row: SkillRow): Skill {
     created_at: row.created_at,
     updated_at: row.updated_at,
   };
+}
+
+function compatibilityFromFrontmatter(frontmatter: Record<string, unknown>): string | null {
+  const value = frontmatter.compatibility;
+  return typeof value === 'string' && value.trim() && value.trim().length <= 500
+    ? value.trim()
+    : null;
 }
 
 function parseObject(value: string): Record<string, unknown> {

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -1253,6 +1253,7 @@ describe('Managed Agents API', () => {
       const skillContent = `---
 name: contract-skill
 description: Exercises the standard skill API.
+compatibility: Requires network access and Python 3.9+
 ---
 
 # Contract Skill
@@ -1273,6 +1274,7 @@ Use this in API tests.
       expect(create.body.type).toBe('skill');
       expect(create.body.source).toBe('custom');
       expect(create.body.display_title).toBe('Contract Skill');
+      expect(create.body.compatibility).toBe('Requires network access and Python 3.9+');
       expect(create.body.latest_version).toBeTruthy();
 
       const skillId = create.body.id;
@@ -1292,6 +1294,7 @@ Use this in API tests.
       expect(get.body.id).toBe(skillId);
       expect(get.body.name).toBe('contract-skill');
       expect(get.body.description).toBe('Exercises the standard skill API.');
+      expect(get.body.compatibility).toBe('Requires network access and Python 3.9+');
 
       const customList = await getJson('/v1/skills?source=custom');
       expect(customList.body.data.some((item: any) => item.id === skillId)).toBe(true);

--- a/tests/unit/console-pages.test.ts
+++ b/tests/unit/console-pages.test.ts
@@ -226,6 +226,7 @@ function populatedConsoleData(): ConsoleData {
       name: 'ui-review',
       display_title: 'UI Review',
       description: 'Checklist for dashboard polish.',
+      compatibility: 'Requires git and network access.',
       source: 'custom',
       latest_version: '202607230001',
       versions: [{ id: '202607230001', created_at: now, latest: true }],

--- a/tests/unit/skill-resources.test.ts
+++ b/tests/unit/skill-resources.test.ts
@@ -8,6 +8,7 @@ describe('skill resource helpers', () => {
       id: 'skill_a',
       type: 'skill',
       name: 'a',
+      compatibility: 'Requires network access',
       file: 'a/SKILL.md',
       versions: [{ id: '1', created_at: null, latest: true }],
     });
@@ -33,6 +34,7 @@ function testSkill(name: string): Skill {
     name,
     display_title: name,
     description: `${name} description`,
+    compatibility: 'Requires network access',
     instructions: `${name} instructions`,
     frontmatter: {},
     file: `${name}/SKILL.md`,

--- a/tests/unit/skills.test.ts
+++ b/tests/unit/skills.test.ts
@@ -18,6 +18,7 @@ import {
 const SKILL_MD = `---
 name: code-review
 description: Reviews code for bugs and style
+compatibility: Requires git and network access
 ---
 
 # Code Review Skill
@@ -33,6 +34,7 @@ describe('Skills', () => {
       const skill = parseSkill(SKILL_MD, 'package-name')!;
       expect(skill.name).toBe('code-review');
       expect(skill.description).toBe('Reviews code for bugs and style');
+      expect(skill.compatibility).toBe('Requires git and network access');
       expect(skill.instructions).toContain('# Code Review Skill');
       expect(skill.instructions).toContain('Check for bugs');
     });
@@ -46,6 +48,11 @@ describe('Skills', () => {
       const skill = parseSkill('---\nname: x\n---\nbody', 'f');
       expect(skill).toBeNull();
     });
+
+    it('rejects invalid compatibility metadata', () => {
+      expect(parseSkill('---\nname: x\ndescription: x\ncompatibility: []\n---\nbody', 'x')).toBeNull();
+      expect(parseSkill(`---\nname: x\ndescription: x\ncompatibility: ${'x'.repeat(501)}\n---\nbody`, 'x')).toBeNull();
+    });
   });
 
   describe('round-trip (Property 2)', () => {
@@ -56,6 +63,7 @@ describe('Skills', () => {
 
       expect(second.name).toBe(first.name);
       expect(second.description).toBe(first.description);
+      expect(second.compatibility).toBe(first.compatibility);
       expect(second.instructions).toBe(first.instructions);
     });
   });
@@ -149,6 +157,7 @@ function testSkill(name: string, description: string, instructions: string): Ski
     name,
     display_title: name,
     description,
+    compatibility: null,
     instructions,
     frontmatter: {},
     file: `${name}/SKILL.md`,


### PR DESCRIPTION
## Summary
- validate and preserve the standard Agent Skills `compatibility` frontmatter field
- expose compatibility requirements through `/v1/skills`
- make compatibility searchable and visible in the Console Skill drawer
- document the 500-character limit and the non-executable trust boundary

## Safety boundary
Compatibility is rendered as untrusted descriptive text. It never installs packages, grants permissions, or enables network access.

## Verification
- `npm run typecheck`
- `npm test` (583 passed, 15 skipped)
- `npm run build`
- `git diff --check`

Specification: https://agentskills.io/specification.md#compatibility-field