### PR TITLE
chore: prepare v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.3.5 - 2026-08-20
+
+### Highlights
+
+- **Agent Skills compatibility metadata**: validates and preserves the standard
+  optional `compatibility` field (1–500 characters), exposes it through the API,
+  and renders it safely in Console search and detail views.
+- **Instant Codespaces evaluation**: adds a development-container configuration
+  and documented one-click path to build and open the local Console without
+  preparing a host Node.js environment.
+- **Verified DSH onboarding**: adds runtime/auth preflight checks and links the
+  bilingual DeepSeek Harness developer walkthrough and operator tools.
+- **Release-aligned Agent Plugin**: pins the portable MCP plugin to the v0.3.5
+  multi-architecture bridge image produced from this tag.
+
 ## 0.3.4 - 2026-08-19
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ machine or in your own infrastructure.
 > connects 25 AI client targets to 2,000+ models through a local stdio MCP bridge.
 
 ```bash
-git clone --branch v0.3.4 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.5 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -144,7 +144,7 @@ to identify the first broken runtime boundary.
 ## Quick Start
 
 ```bash
-git clone --branch v0.3.4 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.5 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -165,10 +165,10 @@ The six-tool MCP bridge is published as a multi-architecture OCI image. Start
 the Harness API, then add this stdio command to an MCP client:
 
 ```bash
-docker pull ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4
+docker pull ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.5
 docker run --rm -i \
   -e MANAGED_AGENTS_URL=http://host.docker.internal:3000 \
-  ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4
+  ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.5
 ```
 
 For an authenticated remote runtime, also pass `MANAGED_AGENTS_API_KEY`. The
@@ -192,7 +192,7 @@ copilot plugin install sandbaseai/sandbase-harness:agent-plugin
 ```
 
 The plugin passes these environment variables through to the pinned
-`ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4` image. It does not store a key
+`ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.5` image. It does not store a key
 in `plugin.json`, `mcp.json`, or the installed plugin files. On Linux, the
 plugin's Docker command maps `host.docker.internal` through `host-gateway`.
 
@@ -455,7 +455,7 @@ init smoke, and `examples/basic` startup smoke.
 - [Self-host the SandBase agent runtime](https://www.ssdnodes.com/learn/self-host-sandbase-agent-runtime)
   by SSD Nodes — an independent VPS walkthrough covering installation, agent
   configuration, MCP servers, sandbox modes, and reverse-proxy deployment. The
-  article demonstrates v0.3.2; use the current release command above for v0.3.4.
+  article demonstrates v0.3.2; use the current release command above for v0.3.5.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@ Memory、凭证、审计日志、事件回放和可视化 Console 放在同一�
 
 ![SandBase Harness 架构](docs/assets/sandbase-harness-architecture.svg)
 
-> 当前稳定版本：[v0.3.4](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.4)
+> 当前稳定版本：[v0.3.5](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.5)
 
 > 官方 MCP Registry：[io.github.sandbaseai/sandbase-harness](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.sandbaseai%2Fsandbase-harness)（状态：`active`）
 
@@ -65,7 +65,7 @@ npm 上未加 scope 的 managed-agents **不是**本项目。请使用带标签�
 GitHub 源码，不要运行 npx managed-agents 或 npm install managed-agents。
 
 ~~~bash
-git clone --branch v0.3.4 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.5 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -83,7 +83,7 @@ node ../sandbase-harness/dist/index.js start
 先构建并暴露本地命令：
 
 ~~~bash
-git clone --branch v0.3.4 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.5 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build:runtime

--- a/agent-plugin/mcp.json
+++ b/agent-plugin/mcp.json
@@ -13,7 +13,7 @@
         "MANAGED_AGENTS_URL",
         "-e",
         "MANAGED_AGENTS_API_KEY",
-        "ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4"
+        "ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.5"
       ]
     }
   }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -125,7 +125,7 @@ spec:
     spec:
       containers:
         - name: runtime
-          image: your-registry.example/sandbase-harness:v0.3.4
+          image: your-registry.example/sandbase-harness:v0.3.5
           workingDir: /app
           command:
             - node

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ the tagged GitHub source release and do not run `npx managed-agents` or
 `npm install managed-agents`.
 
 ```bash
-git clone --branch v0.3.4 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.5 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build

--- a/examples/deepseek-harness/README.md
+++ b/examples/deepseek-harness/README.md
@@ -8,7 +8,7 @@ stdio and exposes agents, sessions, streamed turns, artifacts, and cancellation.
 
 - Node.js 22+
 - DeepSeek Harness with `@deepseek-ai/dsh-mcp-client` and stdio MCP support
-- SandBase Harness v0.3.4 or a source build from this repository
+- SandBase Harness v0.3.5 or a source build from this repository
 
 Last verified on 2026-08-14 against DeepSeek Harness commit
 [`47f9438`](https://github.com/deepseek-ai/deepseek-harness/commit/47f943859bef60e4160492346772ded9b24f765a): the Cordis layer composed cleanly,
@@ -17,7 +17,7 @@ DSH launched the stdio child, and the MCP handshake completed.
 Build the tagged source release and expose its two local executables first:
 
 ```bash
-git clone --branch v0.3.4 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.5 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build:runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "managed-agents",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "managed-agents",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "managed-agents",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Local-first, self-hosted AI agent runtime with Claude Managed Agents-style APIs, sandboxed sessions, memory, tools, audit, replay, and a local Console.",
   "type": "module",
   "homepage": "https://github.com/sandbaseai/sandbase-harness#readme",

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/sandbaseai/sandbase-harness",
     "source": "github"
   },
-  "version": "0.3.4",
+  "version": "0.3.5",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4",
+      "identifier": "ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.5",
       "transport": {
         "type": "stdio"
       },

--- a/tests/unit/v1-local-first-spec.test.ts
+++ b/tests/unit/v1-local-first-spec.test.ts
@@ -82,7 +82,7 @@ describe('v1 local-first architecture spec', () => {
     const chinese = read('README.zh-CN.md');
 
     expect(root).toContain('[中文](./README.zh-CN.md)');
-    expect(chinese).toContain('git clone --branch v0.3.4 --depth 1');
+    expect(chinese).toContain('git clone --branch v0.3.5 --depth 1');
     expect(chinese).toContain('dsh plugin --profile web add managed-agents');
     expect(chinese).toContain('npx --yes github:sandbaseai/sandbase-skills add multi-source-search');
     expect(chinese).toContain('.dsh/skills/multi-source-search');


### PR DESCRIPTION
## Summary

- bump runtime, lockfile, MCP registry, and installation references to v0.3.5
- pin the portable Agent Plugin to the v0.3.5 MCP image
- document Agent Skills compatibility metadata, Codespaces evaluation, and verified DSH onboarding in the changelog

Publishing the corresponding GitHub release will trigger the existing multi-platform GHCR workflow for `linux/amd64` and `linux/arm64` plus build provenance. It will not publish the unrelated npm package named `managed-agents`.

## Validation

- source and test TypeScript checks passed
- 583 tests passed; 15 environment-dependent Kubernetes tests skipped
- runtime and Console production builds passed
- package dry run verified 47 files
- release startup smoke passed on localhost
- `git diff --check`

The initial smoke run was blocked only by the local command sandbox's loopback-bind restriction; rerunning the same smoke command with localhost permission returned `release smoke: ok`.
