### PR TITLE
fix: make DSH bundle clean-profile safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.7 - 2026-08-20
+
+### Fixes
+
+- Makes the DeepSeek Harness bundle boot in a clean Web profile when
+  `MANAGED_AGENTS_API_KEY` is unset by keeping all MCP `env` values string-typed.
+- Resolves the MCP entry from the installed profile instead of requiring a
+  globally linked `managed-agents-mcp` executable on `PATH`.
+- Replaces the ambiguous npm-name installation command with a pinned local
+  source install, preventing resolution of the unrelated unscoped package.
+
 ## 0.3.6 - 2026-08-20
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ machine or in your own infrastructure.
 > connects 25 AI client targets to 2,000+ models through a local stdio MCP bridge.
 
 ```bash
-git clone --branch v0.3.6 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.7 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -102,11 +102,14 @@ then boot that profile:
 
 ```bash
 export MANAGED_AGENTS_URL=http://127.0.0.1:3000
-dsh plugin --profile web add managed-agents
+# Run from the sibling my-agents workspace created above.
+dsh plugin --profile web add -w ../sandbase-harness
 dsh web
 ```
 
-The patch starts `managed-agents-mcp` over stdio. DSH can then list agents,
+The profile installs the verified source checkout directly; it does not resolve
+the unrelated unscoped npm package. The patch starts the bundled MCP entry over
+stdio. DSH can then list agents,
 create and run sessions, inspect results and artifacts, and stop work through
 native `mcp__sandbase__*` tools. See
 [`examples/deepseek-harness`](examples/deepseek-harness/README.md) for the full
@@ -144,7 +147,7 @@ to identify the first broken runtime boundary.
 ## Quick Start
 
 ```bash
-git clone --branch v0.3.6 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.7 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -165,10 +168,10 @@ The six-tool MCP bridge is published as a multi-architecture OCI image. Start
 the Harness API, then add this stdio command to an MCP client:
 
 ```bash
-docker pull ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.6
+docker pull ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.7
 docker run --rm -i \
   -e MANAGED_AGENTS_URL=http://host.docker.internal:3000 \
-  ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.6
+  ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.7
 ```
 
 For an authenticated remote runtime, also pass `MANAGED_AGENTS_API_KEY`. The
@@ -192,7 +195,7 @@ copilot plugin install sandbaseai/sandbase-harness:agent-plugin
 ```
 
 The plugin passes these environment variables through to the pinned
-`ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.6` image. It does not store a key
+`ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.7` image. It does not store a key
 in `plugin.json`, `mcp.json`, or the installed plugin files. On Linux, the
 plugin's Docker command maps `host.docker.internal` through `host-gateway`.
 
@@ -455,7 +458,7 @@ init smoke, and `examples/basic` startup smoke.
 - [Self-host the SandBase agent runtime](https://www.ssdnodes.com/learn/self-host-sandbase-agent-runtime)
   by SSD Nodes — an independent VPS walkthrough covering installation, agent
   configuration, MCP servers, sandbox modes, and reverse-proxy deployment. The
-  article demonstrates v0.3.2; use the current release command above for v0.3.6.
+  article demonstrates v0.3.2; use the current release command above for v0.3.7.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@ Memory、凭证、审计日志、事件回放和可视化 Console 放在同一�
 
 ![SandBase Harness 架构](docs/assets/sandbase-harness-architecture.svg)
 
-> 当前稳定版本：[v0.3.6](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.6)
+> 当前稳定版本：[v0.3.7](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.7)
 
 > 官方 MCP Registry：[io.github.sandbaseai/sandbase-harness](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.sandbaseai%2Fsandbase-harness)（状态：`active`）
 
@@ -65,7 +65,7 @@ npm 上未加 scope 的 managed-agents **不是**本项目。请使用带标签�
 GitHub 源码，不要运行 npx managed-agents 或 npm install managed-agents。
 
 ~~~bash
-git clone --branch v0.3.6 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.7 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build
@@ -80,18 +80,17 @@ node ../sandbase-harness/dist/index.js start
 
 ## 接入 DeepSeek Harness
 
-先构建并暴露本地命令：
+先构建固定版本源码并启动 Runtime：
 
 ~~~bash
-git clone --branch v0.3.6 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.7 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build:runtime
-npm link
 
 mkdir ../my-agents && cd ../my-agents
-managed-agents init
-managed-agents start
+node ../sandbase-harness/dist/index.js init
+node ../sandbase-harness/dist/index.js start
 ~~~
 
 另开终端，把插件安装到 DSH Web Profile：
@@ -99,7 +98,8 @@ managed-agents start
 ~~~bash
 export MANAGED_AGENTS_URL=http://127.0.0.1:3000
 # 仅在 Runtime 开启认证时设置 MANAGED_AGENTS_API_KEY
-dsh plugin --profile web add managed-agents
+# 从上面创建的 my-agents 目录运行，直接安装固定源码，不解析 npm 同名包
+dsh plugin --profile web add -w ../sandbase-harness
 dsh web
 ~~~
 

--- a/agent-plugin/mcp.json
+++ b/agent-plugin/mcp.json
@@ -13,7 +13,7 @@
         "MANAGED_AGENTS_URL",
         "-e",
         "MANAGED_AGENTS_API_KEY",
-        "ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.6"
+        "ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.7"
       ]
     }
   }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -125,7 +125,7 @@ spec:
     spec:
       containers:
         - name: runtime
-          image: your-registry.example/sandbase-harness:v0.3.6
+          image: your-registry.example/sandbase-harness:v0.3.7
           workingDir: /app
           command:
             - node

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ the tagged GitHub source release and do not run `npx managed-agents` or
 `npm install managed-agents`.
 
 ```bash
-git clone --branch v0.3.6 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.7 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build

--- a/examples/deepseek-harness/README.md
+++ b/examples/deepseek-harness/README.md
@@ -8,28 +8,26 @@ stdio and exposes agents, sessions, streamed turns, artifacts, and cancellation.
 
 - Node.js 22+
 - DeepSeek Harness with `@deepseek-ai/dsh-mcp-client` and stdio MCP support
-- SandBase Harness v0.3.6 or a source build from this repository
+- SandBase Harness v0.3.7 or a source build from this repository
 
 Last verified on 2026-08-14 against DeepSeek Harness commit
 [`47f9438`](https://github.com/deepseek-ai/deepseek-harness/commit/47f943859bef60e4160492346772ded9b24f765a): the Cordis layer composed cleanly,
 DSH launched the stdio child, and the MCP handshake completed.
 
-Build the tagged source release and expose its two local executables first:
+Build the tagged source release and start the runtime from that checkout:
 
 ```bash
-git clone --branch v0.3.6 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
+git clone --branch v0.3.7 --depth 1 https://github.com/sandbaseai/sandbase-harness.git
 cd sandbase-harness
 npm ci
 npm run build:runtime
-npm link
 mkdir ../my-agents && cd ../my-agents
-managed-agents init
-managed-agents start
+node ../sandbase-harness/dist/index.js init
+node ../sandbase-harness/dist/index.js start
 ```
 
 The unscoped `managed-agents` package on npm is not SandBase Harness. Do not
-use `npx managed-agents`; `npm link` above links only the verified source
-checkout.
+use `npx managed-agents` or install that registry package.
 
 In another terminal, install this bundle into the Web profile and start DSH:
 
@@ -51,7 +49,9 @@ else
     "$MANAGED_AGENTS_URL/v1/agents"
 fi
 
-dsh plugin --profile web add managed-agents
+# Run from the sibling my-agents workspace created above. This installs the
+# fixed source checkout directly instead of resolving the npm package name.
+dsh plugin --profile web add -w ../sandbase-harness
 dsh web
 ```
 
@@ -76,9 +76,8 @@ The command copies the complete open-source Skill to
 page-reading tools without a SandBase account; optional provider-backed
 workflows remain opt-in.
 
-For source development, load the included patch directly after building and
-put `dist/mcp` on `PATH`, or replace `command` with the absolute path to the
-built executable in a private test overlay.
+The bundle resolves its MCP entry from the installed Web profile, so a clean
+profile needs neither a global `npm link` nor a custom `PATH` entry.
 
 DSH receives these tools under its stable MCP namespace:
 
@@ -112,8 +111,8 @@ stronger isolation boundary.
 
 ## Troubleshooting
 
-- `MCP startup failed`: build or install `managed-agents` and confirm
-  `managed-agents-mcp` is on `PATH`.
+- `MCP startup failed`: confirm the source checkout was built before running
+  `dsh plugin --profile web add -w ../sandbase-harness`.
 - `fetch failed`: start the runtime and check `MANAGED_AGENTS_URL`.
 - `401` or `403`: set `MANAGED_AGENTS_API_KEY` to a key accepted by the
   runtime.

--- a/examples/deepseek-harness/cordis.yml
+++ b/examples/deepseek-harness/cordis.yml
@@ -4,8 +4,10 @@
       config:
         serverName: sandbase
         transport: stdio
-        command: managed-agents-mcp
+        command: node
+        args:
+          - !!js dshHomePath('profiles/web/node_modules/managed-agents/dist/mcp/index.js')
         env:
-          MANAGED_AGENTS_URL: !!js process.env.MANAGED_AGENTS_URL
-          MANAGED_AGENTS_API_KEY: !!js process.env.MANAGED_AGENTS_API_KEY
+          MANAGED_AGENTS_URL: !!js process.env.MANAGED_AGENTS_URL ?? 'http://127.0.0.1:3000'
+          MANAGED_AGENTS_API_KEY: !!js process.env.MANAGED_AGENTS_API_KEY ?? ''
         failOnStartupError: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "managed-agents",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "managed-agents",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "managed-agents",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Local-first, self-hosted AI agent runtime with Claude Managed Agents-style APIs, sandboxed sessions, memory, tools, audit, replay, and a local Console.",
   "type": "module",
   "homepage": "https://github.com/sandbaseai/sandbase-harness#readme",

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/sandbaseai/sandbase-harness",
     "source": "github"
   },
-  "version": "0.3.6",
+  "version": "0.3.7",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.6",
+      "identifier": "ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.7",
       "transport": {
         "type": "stdio"
       },

--- a/tests/unit/mcp-distribution.test.ts
+++ b/tests/unit/mcp-distribution.test.ts
@@ -49,6 +49,16 @@ describe('MCP OCI distribution', () => {
     expect(workflow).not.toContain('MCP_GITHUB_TOKEN');
   });
 
+  it('keeps DSH MCP environment values valid when optional variables are unset', () => {
+    const patch = read('examples/deepseek-harness/cordis.yml');
+
+    expect(patch).toContain('command: node');
+    expect(patch).toContain("dshHomePath('profiles/web/node_modules/managed-agents/dist/mcp/index.js')");
+    expect(patch).toContain("process.env.MANAGED_AGENTS_URL ?? 'http://127.0.0.1:3000'");
+    expect(patch).toContain("process.env.MANAGED_AGENTS_API_KEY ?? ''");
+    expect(patch).not.toContain('MANAGED_AGENTS_API_KEY: !!js process.env.MANAGED_AGENTS_API_KEY\n');
+  });
+
   it('ships a portable Agent Plugin pinned to the release MCP image', () => {
     const packageManifest = JSON.parse(read('package.json')) as { version: string };
     const plugin = JSON.parse(read('agent-plugin/plugin.json')) as {

--- a/tests/unit/v1-local-first-spec.test.ts
+++ b/tests/unit/v1-local-first-spec.test.ts
@@ -82,8 +82,9 @@ describe('v1 local-first architecture spec', () => {
     const chinese = read('README.zh-CN.md');
 
     expect(root).toContain('[中文](./README.zh-CN.md)');
-    expect(chinese).toContain('git clone --branch v0.3.6 --depth 1');
-    expect(chinese).toContain('dsh plugin --profile web add managed-agents');
+    expect(chinese).toContain('git clone --branch v0.3.7 --depth 1');
+    expect(chinese).toContain('dsh plugin --profile web add -w ../sandbase-harness');
+    expect(chinese).not.toContain('npm link');
     expect(chinese).toContain('npx --yes github:sandbaseai/sandbase-skills add multi-source-search');
     expect(chinese).toContain('.dsh/skills/multi-source-search');
     expect(chinese).not.toMatch(/(?:^|\n)npx managed-agents/m);


### PR DESCRIPTION
## Summary

Fix the two deterministic failures behind dshbase L3 `runtime-fail` and prepare v0.3.7:

- keep optional MCP `env` values string-typed when variables are unset
- launch the MCP entry from the package installed in the DSH Web profile instead of relying on a global `managed-agents-mcp` binary
- replace `dsh plugin add managed-agents` with a pinned local source install, avoiding the unrelated unscoped npm package
- update English and Chinese setup/troubleshooting and add regression assertions

## Real clean-profile verification

Using isolated `DSH_HOME`, Harness workspace, and ports against DeepSeek Harness commit `47f943859bef60e4160492346772ded9b24f765a`:

1. fixed v0.3.7 source built successfully
2. `/v1/x/health` returned healthy and `/v1/agents` returned the seeded agent
3. `dsh plugin --profile web add -w <source>` initialized a clean profile and installed `managed-agents 0.3.7`
4. the composed tree contained `mcp-sandbase-harness`
5. DSH logged `sandbase-harness MCP server connected over stdio`
6. DSH Web returned HTTP 200 on the isolated port

## Release gate

`npm run release:check` passed:

- source and test typechecks
- 585 tests passed, 14 skipped
- runtime and production Console builds
- 47-file package dry run
- release smoke

No npm publication is requested.