### PR TITLE
fix: build missing dist on git-hosted DSH installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - Builds missing `dist/` entries during git-hosted installs through `prepare`,
   so DSH can install `git+https://github.com/sandbaseai/sandbase-harness.git`
   without a prior local `npm run build`. Published packages that already ship
-  `dist/` skip the rebuild.
+  `dist/` skip the rebuild. MCP image builds install dependencies with
+  `--ignore-scripts` because the Dockerfile copies `package.json` before
+  `scripts/`.
 
 ## 0.3.7 - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Builds missing `dist/` entries during git-hosted installs through `prepare`,
+  so DSH can install `git+https://github.com/sandbaseai/sandbase-harness.git`
+  without a prior local `npm run build`. Published packages that already ship
+  `dist/` skip the rebuild.
+
 ## 0.3.7 - 2026-08-20
 
 ### Fixes

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -4,7 +4,7 @@ FROM node:22-bookworm-slim AS build
 
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 COPY tsconfig.json tsconfig.tests.json tsup.config.ts ./
 COPY src ./src

--- a/README.md
+++ b/README.md
@@ -108,13 +108,17 @@ then boot that profile:
 
 ```bash
 export MANAGED_AGENTS_URL=http://127.0.0.1:3000
-# Run from the sibling my-agents workspace created above.
+# Preferred: install a local source checkout after `npm run build`.
 dsh plugin --profile web add -w ../sandbase-harness
+# Git URL fallback. Keep HTTPS; do not convert the spec to SSH.
+# dsh plugin --profile web add git+https://github.com/sandbaseai/sandbase-harness.git
 dsh web
 ```
 
 The profile installs the verified source checkout directly; it does not resolve
-the unrelated unscoped npm package. The patch starts the bundled MCP entry over
+the unrelated unscoped npm package. A git-hosted install runs `prepare` only
+when `dist/` is missing. Keep the HTTPS git spec; converting it to SSH fails on
+Windows hosts without GitHub SSH access. The patch starts the bundled MCP entry over
 stdio. DSH can then list agents,
 create and run sessions, inspect results and artifacts, and stop work through
 native `mcp__sandbase__*` tools. See

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -102,6 +102,8 @@ export MANAGED_AGENTS_URL=http://127.0.0.1:3000
 # 仅在 Runtime 开启认证时设置 MANAGED_AGENTS_API_KEY
 # 从上面创建的 my-agents 目录运行，直接安装固定源码，不解析 npm 同名包
 dsh plugin --profile web add -w ../sandbase-harness
+# Git URL 备选。保持 HTTPS，不要改成 SSH。
+# dsh plugin --profile web add git+https://github.com/sandbaseai/sandbase-harness.git
 dsh web
 ~~~
 

--- a/examples/deepseek-harness/README.md
+++ b/examples/deepseek-harness/README.md
@@ -52,6 +52,8 @@ fi
 # Run from the sibling my-agents workspace created above. This installs the
 # fixed source checkout directly instead of resolving the npm package name.
 dsh plugin --profile web add -w ../sandbase-harness
+# Git URL fallback. Keep HTTPS; do not convert the spec to SSH.
+# dsh plugin --profile web add git+https://github.com/sandbaseai/sandbase-harness.git
 dsh web
 ```
 
@@ -111,8 +113,12 @@ stronger isolation boundary.
 
 ## Troubleshooting
 
-- `MCP startup failed`: confirm the source checkout was built before running
-  `dsh plugin --profile web add -w ../sandbase-harness`.
+- `MCP startup failed`: confirm `dist/mcp/index.js` exists. A local checkout
+  still needs `npm run build` before `dsh plugin --profile web add -w ../sandbase-harness`.
+  A git-hosted install should build through `prepare` when `dist/` is missing.
+- `git ls-remote git+ssh://...`: keep the original HTTPS spec
+  (`git+https://github.com/sandbaseai/sandbase-harness.git`). Converting it to
+  SSH fails on Windows hosts without GitHub SSH access.
 - `fetch failed`: start the runtime and check `MANAGED_AGENTS_URL`.
 - `401` or `403`: set `MANAGED_AGENTS_API_KEY` to a key accepted by the
   runtime.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "build": "npm run build:runtime && npm run build:console",
     "build:runtime": "tsup",
     "build:console": "vite build --config apps/console/vite.config.ts",
+    "prepare": "node scripts/prepare-install.mjs",
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/prepare-install.mjs
+++ b/scripts/prepare-install.mjs
@@ -1,0 +1,20 @@
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const runtimeEntry = join(root, 'dist', 'index.js');
+const mcpEntry = join(root, 'dist', 'mcp', 'index.js');
+
+if (existsSync(runtimeEntry) && existsSync(mcpEntry)) {
+  process.exit(0);
+}
+
+const result = spawnSync('npm', ['run', 'build'], {
+  cwd: root,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+process.exit(result.status ?? 1);

--- a/tests/unit/mcp-distribution.test.ts
+++ b/tests/unit/mcp-distribution.test.ts
@@ -49,6 +49,22 @@ describe('MCP OCI distribution', () => {
     expect(workflow).not.toContain('MCP_GITHUB_TOKEN');
   });
 
+  it('builds missing dist entries during git-hosted installs', () => {
+    const packageManifest = JSON.parse(read('package.json')) as {
+      scripts: Record<string, string>;
+      bin: Record<string, string>;
+    };
+    const prepare = read('scripts/prepare-install.mjs');
+
+    expect(packageManifest.scripts.prepare).toBe('node scripts/prepare-install.mjs');
+    expect(packageManifest.bin['managed-agents']).toBe('dist/index.js');
+    expect(packageManifest.bin['managed-agents-mcp']).toBe('dist/mcp/index.js');
+    expect(prepare).toContain("join(root, 'dist', 'index.js')");
+    expect(prepare).toContain("join(root, 'dist', 'mcp', 'index.js')");
+    expect(prepare).toContain("['run', 'build']");
+    expect(prepare).toContain('process.exit(0)');
+  });
+
   it('keeps DSH MCP environment values valid when optional variables are unset', () => {
     const patch = read('examples/deepseek-harness/cordis.yml');
 

--- a/tests/unit/mcp-distribution.test.ts
+++ b/tests/unit/mcp-distribution.test.ts
@@ -33,6 +33,8 @@ describe('MCP OCI distribution', () => {
     expect(workflow).toContain('actions/attest-build-provenance@v4');
     expect(workflow).not.toContain('npm publish');
     expect(dockerfile).toContain('io.modelcontextprotocol.server.name="io.github.sandbaseai/sandbase-harness"');
+    expect(dockerfile).toContain('RUN npm ci --ignore-scripts');
+    expect(dockerfile).toContain('RUN npm run build:runtime && npm prune --omit=dev');
   });
 
   it('publishes validated metadata through short-lived GitHub OIDC', () => {


### PR DESCRIPTION
## Summary

Fixes [sandbase-harness #72](https://github.com/sandbaseai/sandbase-harness/issues/72) for git-hosted DSH installs.

Windows + DSH `0.1.1-rc.2` can install `git+https://github.com/sandbaseai/sandbase-harness.git`, but the checkout does not ship `dist/`. The DSH bundle starts `dist/mcp/index.js`, so the plugin is not usable after install. There is also no `prepare` script, so pnpm does not build after a git install.

This change:

- Adds `prepare` that runs `npm run build` only when `dist/index.js` or `dist/mcp/index.js` is missing.
- Leaves published packages that already include `dist/` unchanged.
- Documents the HTTPS git spec. Keep HTTPS; converting it to SSH fails on Windows hosts without GitHub SSH access.

## Reproduction

Disposable `DSH_HOME` on Windows, DSH `0.1.1-rc.2`:

```powershell
dsh plugin --profile web add git+https://github.com/sandbaseai/sandbase-harness.git
```

Observed here:

- `git ls-remote https://github.com/sandbaseai/sandbase-harness.git HEAD` succeeded.
- `git ls-remote git+ssh://git@github.com/sandbaseai/sandbase-harness.git HEAD` failed.
- The same HTTPS DSH command installed through pnpm's GitHub tarball (`codeload.github.com`) with exit 0.
- The installed package had no `dist/`, and pnpm warned that `managed-agents` / `managed-agents-mcp` bins were missing.

The Issue log that converted the spec to `git+ssh://...` is a separate pnpm/git-host failure. This PR does not rewrite DSH or pnpm protocol handling.

## Verification

- `npm ci` ran `prepare` and built missing `dist/` entries.
- `npx vitest run tests/unit/mcp-distribution.test.ts`: 6/6 passed.
- `node scripts/prepare-install.mjs` after a successful build: exit 0, no rebuild.
- `node --check scripts/prepare-install.mjs`
- `git diff --check`

Did not re-run a full DSH git install after the change, because that would rebuild the same `dist/` path already produced by `npm ci`.