### PR TITLE
fix: make session token accounting canonical

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,100 @@
+# SandBase Harness Maintainer Guide
+
+## Project
+
+SandBase Harness (`managed-agents`) is a local-first, self-hosted runtime for
+AI agents. It provides a Claude Managed Agents-style `/v1` API and local
+Console, persistent sessions, resumable event streams, SQLite metadata,
+sandbox providers, MCP toolsets, credential vaults, memory, skills, snapshots,
+audit/replay, and a TypeScript SDK.
+
+The main execution path is:
+
+`API/SDK → SessionManager → ContextBuilder → AgentStrategy → Model/MCP tools → Sandbox`
+
+Important boundaries:
+
+- `src/api/`: HTTP routes and protocol adapters.
+- `src/core/session/`: session lifecycle, event log, recovery, context, tools.
+- `src/strategy/`: model-loop implementations.
+- `src/sandbox/`: local, Docker, Kubernetes, and self-hosted execution.
+- `src/core/db/`: SQLite connection and embedded migrations.
+- `src/core/runtime/`: bootstrap and service composition.
+- `apps/console/`: React/Vite operator console.
+- `tests/unit/` and `tests/integration/`: regression and behavior coverage.
+
+Requirements are Node.js 22+, npm 10+, and a configured model provider. The
+local sandbox is not a security boundary; untrusted agent code must use an
+isolated provider such as Docker or Kubernetes.
+
+## Maintainer role
+
+Act as the repository owner and maintainer. Keep the runtime safe, usable,
+local-first, and backwards compatible. Handle routine repository work without
+waiting for a separate approval when it is within the scope of an existing
+Issue or PR:
+
+1. Triage new Issues. Reproduce from the report and source, label the failure
+   boundary, identify duplicates, and leave an evidence-based comment.
+2. For valid bugs, create a focused branch named `fix/issue-<number>-<slug>`.
+   For features use `feat/issue-<number>-<slug>`. Reference `Fixes #<number>`
+   or `Closes #<number>` in the PR body when the work resolves it.
+3. Implement the smallest complete fix, add regression tests, update docs or
+   migrations when behavior changes, and preserve unrelated user changes.
+4. Review open PRs as an owner: inspect the actual diff, verify security and
+   lifecycle behavior, run the relevant checks, and request changes when the
+   evidence is insufficient. Do not merge a PR merely because it is marked
+   mergeable.
+5. Merge PRs that have passing required checks, a focused scope, adequate
+   tests, and no unresolved correctness or security concern. Prefer squash
+   merging for small focused fixes and delete the merged branch.
+6. After merging, verify the target Issue is actually resolved. Related
+   installer or third-party service failures should be separated and referred
+   to the responsible project rather than claimed as fixed here.
+
+## Verification gate
+
+Before opening or merging a code PR, run as much of this gate as the change
+allows:
+
+```bash
+npm ci
+npm run typecheck
+npm test
+npm run build
+npm run package:check
+```
+
+For a narrow change, at minimum run the directly affected unit/integration
+tests plus typecheck. If a check cannot run, report the exact blocker in the
+PR and do not describe the change as fully verified.
+
+## Review priorities
+
+- Never weaken sandbox path checks, credential handling, API authentication,
+  tool confirmation, or secret encryption for convenience.
+- Treat event logs as append-only and preserve resumable SSE ordering.
+- Keep session state transitions valid and make cleanup/recovery idempotent.
+- Token usage must have one canonical accounting event per model request;
+  projection events must not silently multiply totals.
+- Validate model/tool stream data before persisting or executing a confirmed
+  tool call. Do not trust a parsed projection when raw stream integrity is
+  required.
+- Database migrations must be ordered, repeatable in fresh and existing
+  databases, and covered by tests.
+- Do not commit generated `dist/` output unless the release/distribution
+  workflow explicitly requires it. Git-hosted installs rely on `prepare`.
+
+## Issue and PR communication
+
+Use concise, factual comments. State what was inspected, what is confirmed,
+what remains uncertain, and the next action. Link related Issues/PRs. Never
+claim a provider, platform, or plugin-manager bug is fixed without testing the
+affected boundary.
+
+## Release and security notes
+
+The npm package is named `managed-agents`, but an unrelated unscoped package
+must not be recommended as this project. Keep Git install examples on HTTPS
+for cross-platform compatibility. Do not expose API keys or secret material in
+logs, fixtures, PRs, `plugin.json`, or `mcp.json`.

--- a/src/api/routes/runtime.ts
+++ b/src/api/routes/runtime.ts
@@ -113,7 +113,8 @@ export function runtimeRoutes(deps: ServerDeps) {
         COALESCE(SUM(tokens_in), 0) AS input_tokens,
         COALESCE(SUM(tokens_out), 0) AS output_tokens,
         COALESCE(AVG(NULLIF(duration_ms, 0)), 0) AS average_duration_ms
-       FROM events`,
+       FROM events
+       WHERE type = 'span.model_request_end'`,
     ).get() as { total: number; input_tokens: number; output_tokens: number; average_duration_ms: number };
     const files = deps.db.prepare(
       `SELECT

--- a/src/core/session/event-logger.ts
+++ b/src/core/session/event-logger.ts
@@ -95,6 +95,21 @@ export class EventLogger {
     const row = stmt.get(sessionId) as { max_seq: number | null } | undefined;
     return row?.max_seq ?? 0;
   }
+
+  /**
+   * Add usage from one model request to the session aggregate.
+   * Callers must invoke this once per model request, not once per event
+   * projection, because several events may describe the same request.
+   */
+  recordUsage(sessionId: string, tokensIn: number, tokensOut: number): void {
+    this.db.prepare(`
+      UPDATE sessions
+      SET usage_tokens_in = COALESCE(usage_tokens_in, 0) + ?,
+          usage_tokens_out = COALESCE(usage_tokens_out, 0) + ?,
+          updated_at = datetime('now')
+      WHERE id = ?
+    `).run(tokensIn, tokensOut, sessionId);
+  }
 }
 
 // ============================================================

--- a/src/core/session/in-memory-event-log.ts
+++ b/src/core/session/in-memory-event-log.ts
@@ -40,6 +40,10 @@ export class InMemoryEventLog implements EventLogWriter {
     return this.events.length;
   }
 
+  recordUsage(_sessionId: string, _tokensIn: number, _tokensOut: number): void {
+    // Ephemeral delegated sessions have no durable session aggregate.
+  }
+
   getEvents(): SessionEvent[] {
     return this.events;
   }

--- a/src/strategy/default-strategy.ts
+++ b/src/strategy/default-strategy.ts
@@ -98,6 +98,10 @@ export class DefaultStrategy implements AgentStrategy {
             durationMs: Date.now() - startTime,
           });
           broadcast(spanEvent);
+          // Persist the aggregate once per model request. The same usage is
+          // intentionally copied to projected message/tool events for local
+          // attribution, so metrics must not sum those projections.
+          eventLog.recordUsage(session.id, tokensIn, tokensOut);
 
           // Emit agent.thinking for reasoning output (extended-thinking models)
           const reasoning = (step as { reasoning?: string }).reasoning;

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -109,6 +109,8 @@ export interface EventLogWriter {
     delegationDepth?: number;
   }): SessionEvent;
   getLatestSeq(sessionId: string): number;
+  /** Record canonical model usage for the owning session. */
+  recordUsage(sessionId: string, tokensIn: number, tokensOut: number): void;
 }
 
 // ============================================================

--- a/tests/unit/event-logger.test.ts
+++ b/tests/unit/event-logger.test.ts
@@ -105,6 +105,23 @@ describe('Event Logger', () => {
     });
   });
 
+  describe('recordUsage', () => {
+    it('accumulates canonical model-request usage on the session', () => {
+      logger.recordUsage('sess_test', 120, 30);
+      logger.recordUsage('sess_test', 80, 20);
+
+      const row = db.prepare(
+        'SELECT usage_tokens_in, usage_tokens_out FROM sessions WHERE id = ?',
+      ).get('sess_test') as { usage_tokens_in: number; usage_tokens_out: number };
+
+      expect(row).toEqual({ usage_tokens_in: 200, usage_tokens_out: 50 });
+    });
+
+    it('does not change usage when the session does not exist', () => {
+      expect(() => logger.recordUsage('sess_missing', 10, 5)).not.toThrow();
+    });
+  });
+
   describe('append-only invariant (Property 7)', () => {
     it('event count monotonically increases', () => {
       const counts: number[] = [];


### PR DESCRIPTION
## Summary

Fixes #77.

- Treats `span.model_request_end` as the canonical per-request usage record in runtime metrics.
- Accumulates one usage total per model request in `sessions.usage_tokens_in/out`.
- Keeps usage on projected message/tool events for attribution without double-counting it in aggregate metrics.
- Adds regression coverage for session usage accumulation.
- Adds the repository maintainer guide in `AGENTS.md`.

## Verification

- `npm run typecheck`
- `npm test` — 77 passed, 2 skipped; 587 passed, 14 skipped
- `npm run build`
- `npm run package:check`
- `git diff --check`

The separate cache-bucket and auxiliary model-call accounting concerns from #77 remain follow-up work because they require extending the usage schema and wiring compaction/evaluator dependencies explicitly.
