### PR TITLE
docs: link agent installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ init smoke, and `examples/basic` startup smoke.
 
 ## Documentation
 
+- [Agent / MCP installation guide](llms-install.md)
 - [Installation](docs/installation.md)
 - [Usage Guide](docs/usage.md)
 - [API Reference](docs/api.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -173,6 +173,7 @@ my-agents/
 
 ## 文档
 
+- [Agent / MCP 安装指南](./llms-install.md)
 - [安装](./docs/installation.md)
 - [使用指南](./docs/usage.md)
 - [API](./docs/api.md)


### PR DESCRIPTION
## Summary
- link `llms-install.md` from the English README documentation section
- link the same guide from the Chinese README

This makes the reproducible Agent/MCP setup guide discoverable from the project landing page.

Validation: `npm run typecheck`, `git diff --check`.