### PR TITLE
docs: document the allowBuilds step for git-hosted DSH installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Documentation
+
+- Documents the verified git-hosted DSH install flow: the first add fails with
+  `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` until the exact key pnpm prints is
+  added under `allowBuilds:` in the profile's `pnpm-workspace.yaml`; the
+  second add runs `prepare`, builds `dist/`, creates both bins, and joins the
+  bundle layer. Verified end to end on Windows with DSH `0.1.1-rc.2`.
+
 ## 0.3.8 - 2026-08-30
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -146,7 +146,23 @@ dsh web
 The profile installs the verified source checkout directly; it does not resolve
 the unrelated unscoped npm package. A git-hosted install runs `prepare` only
 when `dist/` is missing. Keep the HTTPS git spec; converting it to SSH fails on
-Windows hosts without GitHub SSH access. The patch starts the bundled MCP entry over
+Windows hosts without GitHub SSH access.
+
+A git-hosted install needs one extra step for pnpm's build allowlist. The
+first `dsh plugin --profile web add` fails with
+`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` and prints the exact key. Add that key
+under `allowBuilds:` in the profile's `pnpm-workspace.yaml`, then re-run the
+same add command; a plain package name does not match a git-hosted
+resolution:
+
+```yaml
+allowBuilds:
+  "managed-agents@https://codeload.github.com/sandbaseai/sandbase-harness/tar.gz/<commit>": true
+```
+
+The second run builds `dist/` through `prepare`, creates the
+`managed-agents` / `managed-agents-mcp` bins, and joins the bundle layer. The
+patch starts the bundled MCP entry over
 stdio. DSH can then list agents,
 create and run sessions, inspect results and artifacts, and stop work through
 native `mcp__sandbase__*` tools. See

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -114,6 +114,19 @@ dsh plugin --profile web add -w ../sandbase-harness
 dsh web
 ~~~
 
+Git 安装需要额外一步 pnpm 构建白名单。第一次 add 会以
+`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` 失败，并打印对应的精确 key；把该 key
+加到 profile 的 `pnpm-workspace.yaml` 的 `allowBuilds:` 下，然后重新运行同一条
+add 命令。裸包名无法匹配 git-hosted 解析：
+
+~~~yaml
+allowBuilds:
+  "managed-agents@https://codeload.github.com/sandbaseai/sandbase-harness/tar.gz/<commit>": true
+~~~
+
+第二次运行会通过 `prepare` 构建 `dist/`，创建 `managed-agents` /
+`managed-agents-mcp` 可执行入口，并挂载 Bundle 层。
+
 DSH 随后可以通过原生 MCP Namespace：
 
 - 列出 Agent

--- a/examples/deepseek-harness/README.md
+++ b/examples/deepseek-harness/README.md
@@ -115,7 +115,10 @@ stronger isolation boundary.
 
 - `MCP startup failed`: confirm `dist/mcp/index.js` exists. A local checkout
   still needs `npm run build` before `dsh plugin --profile web add -w ../sandbase-harness`.
-  A git-hosted install should build through `prepare` when `dist/` is missing.
+  A git-hosted install builds through `prepare` when `dist/` is missing, but
+  pnpm blocks the first run with `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` until
+  the exact key it prints is added under `allowBuilds:` in the profile's
+  `pnpm-workspace.yaml`; re-run the add command afterwards.
 - `git ls-remote git+ssh://...`: keep the original HTTPS spec
   (`git+https://github.com/sandbaseai/sandbase-harness.git`). Converting it to
   SSH fails on Windows hosts without GitHub SSH access.


### PR DESCRIPTION
## Summary

Follow-up to merged #75, informed by [issue #78](https://github.com/sandbaseai/sandbase-harness/issues/78)'s triage and an end-to-end verification pass on Windows with DSH `0.1.1-rc.2`.

Verified flow for the git URL fallback, now documented in both READMEs and the integration guide's troubleshooting:

1. `dsh plugin --profile web add git+https://github.com/sandbaseai/sandbase-harness.git` fails with `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` and prints an exact key.
2. Add that key under `allowBuilds:` in the profile's `pnpm-workspace.yaml`. A plain package name (`"managed-agents": true`) does **not** match a git-hosted resolution — only the printed full spec works.
3. Re-run the same add command: `prepare` builds `dist/`, both bins are created, and `managed-agents` joins `dsh.profile.bundles`.

Observed in the verification run: `dist/index.js` (436 kB) and `dist/mcp/index.js` (15 kB) present, no `Failed to create bin` warnings, bundle layer reconciled. The plugin-hub reporter in #78 hit a separate repeat-install idempotency path, which the maintainer has already triaged to the hub side.

## Verification

- End-to-end disposable `DSH_HOME` install, both failure-then-success passes, on Windows + DSH `0.1.1-rc.2` against current `main` (`66dc765`).
- `git diff --check` passed. Documentation-only change; no code or tests touched.