### PR TITLE
fix(deps): update prefix-safe-json to the published 0.4.3 security release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Security
+
+- Updates `prefix-safe-json` `0.4.2` -> `0.4.3`, a security release fixing
+  GHSA-3xpw-9694-2xxp: the AI SDK adapter used to silently drop raw stream
+  events once it had already observed a call's own terminal, and
+  `takeDecision()` used to read a decision snapshot frozen at `finish()`
+  time instead of live coordinator diagnostics, so late or contradictory
+  lifecycle evidence for a tool call could fail to revoke its execution
+  authority. No public API change. Confirmed the exact vulnerable-then-fixed
+  behavior against this integration's own `createAiSdkV4ExecutionGuard`
+  wrapper (`tests/integration/post-terminal-authority.test.ts`), not just
+  the library's own test suite.
+
 ### Documentation
 
 - Documents the verified git-hosted DSH install flow: the first add fails with

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "commander": "^15.0.0",
         "hono": "^4.6.0",
         "nanoid": "^6.0.1",
-        "prefix-safe-json": "0.4.2",
+        "prefix-safe-json": "0.4.3",
         "yaml": "^2.5.0",
         "zod": "^3.23.0"
       },
@@ -3133,9 +3133,9 @@
       }
     },
     "node_modules/prefix-safe-json": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/prefix-safe-json/-/prefix-safe-json-0.4.2.tgz",
-      "integrity": "sha512-z6ISOFzB5l6mQ4KTydYRJbNJnp+0gvMLWC/Wgl2ajcAEBCgpqTHnxPrYo0/7DoivDZW3h0rkmc7+mNffW7tMPA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/prefix-safe-json/-/prefix-safe-json-0.4.3.tgz",
+      "integrity": "sha512-g1athz1DkW4H6VwWs9RvaH+joVMlcHel8zw4uVRVBsuaryjk7HG4fDSSae1dZgHP8wgddaAXOUPq9E8iyua/uw==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ajv": "^8.20.0"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "commander": "^15.0.0",
     "hono": "^4.6.0",
     "nanoid": "^6.0.1",
-    "prefix-safe-json": "0.4.2",
+    "prefix-safe-json": "0.4.3",
     "yaml": "^2.5.0",
     "zod": "^3.23.0"
   },

--- a/tests/integration/post-terminal-authority.test.ts
+++ b/tests/integration/post-terminal-authority.test.ts
@@ -1,0 +1,123 @@
+/**
+ * prefix-safe-json 0.4.3 (GHSA-3xpw-9694-2xxp) regression coverage for this
+ * integration specifically.
+ *
+ * 0.4.3 fixes three root causes in prefix-safe-json's AI SDK adapter/gate:
+ *   1. the adapter used to silently drop every raw event once it had
+ *      already observed a terminal, so genuinely late/contradictory
+ *      evidence within the same stream never reached the coordinator at
+ *      all;
+ *   2. `takeDecision()` used to read a decision snapshot frozen at
+ *      `finish()` time instead of the coordinator's live diagnostics, so
+ *      evidence recorded *after* `finish()` but *before* that call's
+ *      authority was consumed was never consulted;
+ *   3. a raw event carrying conflicting `id`/`toolCallId` used to silently
+ *      prefer `id` instead of failing the stream closed.
+ *
+ * `default-strategy.ts`'s actual consumption pattern (`for await` drains
+ * the *entire* multi-step `fullStream`, `guard.finish()` is called once
+ * immediately after, then every `guard.takeDecision()` call for
+ * `pendingConfirmationCalls` happens synchronously in the same tick, with
+ * no `await` in between) means root cause #2's literal finish()-to-
+ * takeDecision() async gap does not open here — there is no point where
+ * new evidence could be pushed between this integration's own `finish()`
+ * call and its own decision consumption. What *is* live is root cause #1:
+ * whether a late/contradicting raw event arriving anywhere in the
+ * (potentially multi-step) `fullStream`, before `guard.finish()` is ever
+ * called, correctly revokes authority instead of being silently dropped by
+ * the adapter. Section A proves that directly through this repo's real
+ * `createAiSdkV4ExecutionGuard` (the exact wrapper `default-strategy.ts`
+ * uses), fed the real AI SDK v4 wire part names it translates. Section B
+ * exercises the raw `prefix-safe-json` library's `takeDecision()` directly
+ * against the literal GHSA-3xpw-9694-2xxp repro shape (the one this
+ * integration's own architecture avoids by construction, per above),
+ * confirming the library-level guarantee the dependency bump pulls in is
+ * genuinely present, in case this integration's consumption pattern ever
+ * changes to introduce that gap.
+ */
+import { describe, expect, it } from 'vitest';
+import { createAiSdkV4ExecutionGuard } from '@/strategy/ai-sdk-v4-execution-guard.js';
+import { createAiSdkExecutionGuard } from 'prefix-safe-json';
+
+describe('prefix-safe-json 0.4.3 — post-terminal / stale-authority fix, exercised through this integration', () => {
+  describe('Section A: createAiSdkV4ExecutionGuard (the real ai-sdk-v4-execution-guard.ts wrapper default-strategy.ts uses)', () => {
+    it('a late tool-result for an already-clean call revokes authority instead of being silently dropped', () => {
+      const guard = createAiSdkV4ExecutionGuard();
+      const toolCallId = 'call_write_1';
+
+      // A tool call that looks completely safe on its own, in AI SDK v4's
+      // own wire part names (tool-call-streaming-start / tool-call-delta /
+      // tool-call), exactly what default-strategy.ts's fullStream loop
+      // hands to guard.push().
+      guard.push({ type: 'tool-call-streaming-start', toolCallId, toolName: 'write' });
+      guard.push({ type: 'tool-call-delta', toolCallId, argsTextDelta: '{"path":"a.txt","content":"safe"}' });
+      guard.push({ type: 'tool-call', toolCallId, toolName: 'write', args: '{"path":"a.txt","content":"safe"}' });
+      guard.push({ type: 'finish', finishReason: 'tool-calls' });
+
+      // ...followed, still within the same fullStream, before finish() is
+      // called, by evidence that the SDK actually executed this call
+      // itself / the surrounding step did not actually end cleanly. Before
+      // 0.4.3, the adapter's own "already finished" early return silently
+      // dropped this — the coordinator never saw it, and the decision
+      // stayed "execute".
+      guard.push({ type: 'tool-result', toolCallId, toolName: 'write', result: { ranUpstream: true } });
+
+      const final = guard.finish();
+      const decision = final.decisions.find((d) => d.toolCallId === toolCallId);
+      expect(decision).toBeDefined();
+      expect(decision!.action).not.toBe('execute');
+
+      const authority = guard.takeDecision(decision!.internalId);
+      expect(authority).toBeUndefined();
+    });
+
+    it('control: the same sequence with no late evidence still executes exactly once (the fix above does not overcorrect)', () => {
+      const guard = createAiSdkV4ExecutionGuard();
+      const toolCallId = 'call_write_2';
+
+      guard.push({ type: 'tool-call-streaming-start', toolCallId, toolName: 'write' });
+      guard.push({ type: 'tool-call-delta', toolCallId, argsTextDelta: '{"path":"a.txt","content":"safe"}' });
+      guard.push({ type: 'tool-call', toolCallId, toolName: 'write', args: '{"path":"a.txt","content":"safe"}' });
+      guard.push({ type: 'finish', finishReason: 'tool-calls' });
+
+      const final = guard.finish();
+      const decision = final.decisions.find((d) => d.toolCallId === toolCallId);
+      expect(decision?.action).toBe('execute');
+
+      const authority = guard.takeDecision(decision!.internalId);
+      expect(authority).toBeDefined();
+      expect(authority?.action).toBe('execute');
+
+      const second = guard.takeDecision(decision!.internalId);
+      expect(second).toBeUndefined();
+    });
+  });
+
+  describe('Section B: the raw prefix-safe-json library (createAiSdkExecutionGuard directly) — the literal GHSA-3xpw-9694-2xxp repro shape', () => {
+    it('evidence arriving after finish() but before takeDecision() revokes authority (library-level proof this dependency bump actually pulls in)', () => {
+      const guard = createAiSdkExecutionGuard();
+      const id = 'call_1';
+
+      guard.push({ type: 'tool-input-start', id, toolName: 'write' });
+      guard.push({ type: 'tool-input-delta', id, delta: '{"path":"a.txt","content":"safe"}' });
+      guard.push({ type: 'tool-input-end', id });
+      guard.push({ type: 'finish', finishReason: 'tool-calls' });
+
+      const final = guard.finish();
+      const decision = final.decisions.find((d) => d.toolCallId === id);
+      expect(decision).toBeDefined();
+      expect(decision!.action).toBe('execute');
+
+      // Late evidence, after finish() was already called, before this
+      // call's authority is consumed via takeDecision() — the exact
+      // GHSA-3xpw-9694-2xxp window. default-strategy.ts's own synchronous
+      // consumption pattern avoids ever opening this window (see file
+      // header), but the underlying library guarantee still needs to
+      // hold on its own merits.
+      guard.push({ type: 'tool-result', toolCallId: id, toolName: 'write', result: { ranUpstream: true } });
+
+      const authority = guard.takeDecision(decision!.internalId);
+      expect(authority).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Security update: prefix-safe-json 0.4.2 -> 0.4.3

`prefix-safe-json` moved `0.4.2` -> exact `0.4.3` (`package.json` updated;
`package-lock.json` regenerated with `npm install prefix-safe-json@0.4.3
--save-exact`, not hand-edited).

0.4.3 is a security release (GHSA-3xpw-9694-2xxp) fixing three root causes
in the AI SDK adapter/gate this integration depends on:

1. `AiSdkStreamAdapter.push()` used to silently drop every raw event once
   it had already observed its own terminal, so late/contradictory
   evidence for a call never reached the coordinator at all.
2. `takeDecision()` used to read a decision snapshot frozen at `finish()`
   time instead of the coordinator's live diagnostics, so evidence
   recorded after `finish()` but before that call's authority was
   consumed was never consulted.
3. A raw event carrying conflicting `id`/`toolCallId` used to silently
   prefer `id` instead of failing the stream closed.

No public API change: `createAiSdkExecutionGuard()` / `createAiSdkExecutionLock()`
and the `push`/`finish`/`takeDecision`/`snapshot` surface this integration
reads are unchanged — confirmed directly against the installed package's
`.d.ts` files, not assumed.

## Does this integration's own code actually exercise the fix?

`default-strategy.ts`'s consumption pattern: drain the entire (possibly
multi-step) `fullStream` into one guard, call `guard.finish()` once
immediately after, then resolve every `pendingConfirmationCalls` entry's
`guard.takeDecision()` synchronously in the same tick — no `await` in
between `finish()` and any `takeDecision()` call. That means root cause
#2's literal finish()-to-takeDecision() async window does not open here;
there is no point between this integration's own `finish()` call and its
own decision consumption where new evidence could be pushed.

What *is* live in this integration is root cause #1: whether a
late/contradicting raw event arriving anywhere in the `fullStream` —
before `guard.finish()` is ever called — correctly revokes authority
instead of being silently dropped by the adapter. New test:
`tests/integration/post-terminal-authority.test.ts`:

- **Section A** exercises this repo's real `createAiSdkV4ExecutionGuard`
  (the exact wrapper `default-strategy.ts` uses), fed real AI SDK v4 wire
  part names, with a late `tool-result` arriving for a call that already
  looked complete — proves authority is revoked, plus a control case
  proving the fix does not overcorrect a genuinely clean sequence.
- **Section B** exercises the raw `prefix-safe-json` library
  (`createAiSdkExecutionGuard` directly, real `push`/`finish`/
  `takeDecision`, no synthetic decision object) against the literal
  GHSA-3xpw-9694-2xxp repro shape, confirming the library-level guarantee
  this bump pulls in.

**Proved, not assumed, that this new test actually catches the pre-fix
bug**: ran the identical new test file against the unmodified `0.4.2`
install (dependency bump and test file reverted) — 2 of 3 cases genuinely
failed (`expected 'execute' not to be 'execute'` / a live `execute`
decision where `undefined` was expected), confirming this is a real
regression test.

## Testing

- `npm run typecheck:src`: clean, 0 errors.
- `tests/integration/post-terminal-authority.test.ts` (new): **3/3
  passing** against the real 0.4.3 install.
- `tests/integration/tool-confirmation-reliability.test.ts` (existing,
  provider-level, added in #80): **8/8 passing**, unchanged.
- `npm run build` (runtime + console): passing.
- `npm run package:check`: passing, 55 files, 946.3 kB packed.
- `npm run smoke:release`: passing.
- Full `npx vitest run` (82 files, 626 cases): 71 passed / 24 failed / 2
  skipped. **Proved, not assumed, that all 24 failures are pre-existing
  and unrelated to this change**: ran the identical full suite against
  this same branch with the dependency bump and new test file reverted
  (the prior, unmodified `0.4.2` state) and diffed the two failure lists
  — byte-for-byte identical set of 24 failing test names in both runs
  (`diff` empty). The failures span sandbox execution (`spawn /bin/sh
  ENOENT` — no POSIX shell on this Windows sandbox), Windows `tar.exe`
  path handling, symlinks, and template/snapshot fixtures — none in
  `strategy/`, `ai-sdk-v4-execution-guard`, or the tool-confirmation
  reliability suite proper, consistent with a Windows-sandbox-environment
  limitation rather than anything this change touches.

## Rebase

Rebased onto current `main` (this repo pushes very frequently — rebased
once mid-review to stay current; the intervening commits were all `docs:`
and touched none of this PR's files).

## Changelog

Adds a `### Security` entry under `## Unreleased` in `CHANGELOG.md`,
matching this project's existing convention.
