### PR TITLE
docs: refresh Hugging Face promotion status

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Pending community review:
 - [Awesome Agent-Native Services PR #116](https://github.com/haoruilee/awesome-agent-native-services/pull/116) — curator-approved dossier with v0.3.8 runtime, MCP, session, approval, credential, and audit/replay evidence; merged by the directory maintainer ([verification](https://github.com/haoruilee/awesome-agent-native-services/pull/116#issuecomment-5473455471))
 - [ToolSDK MCP Registry PR #488](https://github.com/toolsdk-ai/toolsdk-mcp-registry/pull/488) — schema and Biome checks pass; maintainer review pending
 - [MCP.Directory submission](https://mcp.directory/submit) — already submitted; directory review pending
-- [Hugging Face agent-harness registry PR #2432](https://github.com/huggingface/huggingface.js/pull/2432) — registry entry corrected to avoid treating `MANAGED_AGENTS_HOME` as an identity marker; checks pass, maintainer merge pending
+- [Hugging Face agent-harness registry PR #2432](https://github.com/huggingface/huggingface.js/pull/2432) — registry entry corrected to avoid treating `MANAGED_AGENTS_HOME` as an identity marker; Cursor Bugbot passes and maintainer merge remains pending ([verification](https://github.com/huggingface/huggingface.js/pull/2432#issuecomment-5475166796))
 - [Agent Switchboard listing PR #44](https://github.com/assafbar2/agentswitchboard.dev/pull/44) — refreshed v0.3.8 listing; maintainer verification pending
 - [Awesome AI Agents 2026 PR #16](https://github.com/Supersynergy/awesome-ai-agents-2026/pull/16) — added SandBase Harness to Agent Runtimes and Platforms; maintainer review pending
 - [Awesome AI Agent Engineering PR #1](https://github.com/sspoisk/awesome-ai-agent-engineering/pull/1) — added SandBase Harness to Deployment; maintainer review pending

--- a/docs/promotion.md
+++ b/docs/promotion.md
@@ -2,6 +2,8 @@
 
 Last checked: 2026-08-31
 
+The latest verification on [Hugging Face agent-harness registry PR #2432](https://github.com/huggingface/huggingface.js/pull/2432) links v0.3.8 and confirms that `MANAGED_AGENTS_HOME` is a data-directory override rather than an identity marker. Cursor Bugbot is successful; the PR remains open and mergeable pending Hugging Face maintainer review. The [follow-up](https://github.com/huggingface/huggingface.js/pull/2432#issuecomment-5475166796) preserves the user-owned API and backend/deployment-dependent isolation boundary, with no endorsement or security-certification claim.
+
 The canonical [Picrew Awesome Agent Harness PR #86](https://github.com/Picrew/awesome-agent-harness/pull/86) remains open and mergeable after a current v0.3.8 source-verification follow-up. Conflicting duplicate [PR #85](https://github.com/Picrew/awesome-agent-harness/pull/85) was closed to leave one maintainer-review path; the catalog entry remains pending and is not an endorsement or security certification.
 
 The new [gVisor DeepSeek Harness integration guide PR #14517](https://github.com/google/gvisor/pull/14517) documents an explicit Docker → `runsc` → gVisor execution path for selected Harness commands. A maintainer-facing [follow-up](https://github.com/google/gvisor/pull/14517#issuecomment-5472929623) links SandBase Harness as a complementary Harness-side reference for governed sessions, MCP admission/approvals, credential scoping, audit/replay, and selectable backends. The note explicitly does not claim that SandBase replaces gVisor or provides universal kernel isolation; the PR remains open and maintainer review is pending.


### PR DESCRIPTION
Record the latest Hugging Face registry verification follow-up and current maintainer-review state.

- destination: https://github.com/huggingface/huggingface.js/pull/2432
- Cursor Bugbot passed; maintainer merge remains pending
- identity metadata correction and deployment boundary are documented